### PR TITLE
Feature/bootstrap token

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ sequenceDiagram
 TokenSmith now supports both token exchange and Casbin-first AuthN/AuthZ middleware.
 
 - New adopters: [`docs/getting-started.md`](docs/getting-started.md)
+- Internal-only service-to-service setup: [`docs/getting-started.md#15-internal-service-to-service-only-no-external-user-token-exchange`](docs/getting-started.md#15-internal-service-to-service-only-no-external-user-token-exchange)
+- Internal-only service-to-service quick guide: [`docs/internal-service-auth.md`](docs/internal-service-auth.md)
 - Casbin model and policy workflow: [`docs/casbin-first-guide.md`](docs/casbin-first-guide.md)
 - Policy loading and `policy_version`: [`docs/authz_policy.md`](docs/authz_policy.md)
 - Operations and rollout modes: [`docs/authz_operations.md`](docs/authz_operations.md)

--- a/cmd/tokenservice/main.go
+++ b/cmd/tokenservice/main.go
@@ -13,17 +13,18 @@ import (
 )
 
 var (
-	issuer           string
-	port             int
-	clusterID        string
-	openCHAMIID      string
-	oidcIssuerURL    string
-	oidcClientID     string
-	oidcClientSecret string
-	configPath       string
-	keyFile          string
-	keyDir           string
-	nonEnforcing     bool // Skip validation checks and only log errors
+	issuer                string
+	port                  int
+	clusterID             string
+	openCHAMIID           string
+	oidcIssuerURL         string
+	oidcClientID          string
+	oidcClientSecret      string
+	configPath            string
+	keyFile               string
+	keyDir                string
+	bootstrapJTIStorePath string
+	nonEnforcing          bool // Skip validation checks and only log errors
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/tokenservice/mint_bootstrap_token.go
+++ b/cmd/tokenservice/mint_bootstrap_token.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openchami/tokensmith/pkg/keys"
+	"github.com/openchami/tokensmith/pkg/tokenservice"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mintBootstrapServiceID   string
+	mintBootstrapTarget      string
+	mintBootstrapScopes      string
+	mintBootstrapTTL         time.Duration
+	mintBootstrapIssuer      string
+	mintBootstrapClusterID   string
+	mintBootstrapOpenCHAMIID string
+	mintBootstrapPrivateKey  string
+)
+
+var mintBootstrapTokenCmd = &cobra.Command{
+	Use:   "mint-bootstrap-token",
+	Short: "Mint a one-time bootstrap token for service startup",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if strings.TrimSpace(mintBootstrapPrivateKey) == "" {
+			return fmt.Errorf("--key-file is required")
+		}
+		if strings.TrimSpace(mintBootstrapServiceID) == "" {
+			return fmt.Errorf("--service-id is required")
+		}
+		if strings.TrimSpace(mintBootstrapTarget) == "" {
+			return fmt.Errorf("--target-service is required")
+		}
+		if mintBootstrapTTL <= 0 {
+			return fmt.Errorf("--ttl must be greater than zero")
+		}
+
+		keyManager := keys.NewKeyManager()
+		if err := keyManager.LoadPrivateKey(mintBootstrapPrivateKey); err != nil {
+			return fmt.Errorf("failed to load private key: %w", err)
+		}
+
+		svc, err := tokenservice.NewTokenService(keyManager, tokenservice.Config{
+			Issuer:      mintBootstrapIssuer,
+			ClusterID:   mintBootstrapClusterID,
+			OpenCHAMIID: mintBootstrapOpenCHAMIID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to initialize token service: %w", err)
+		}
+
+		scopes := parseScopeCSV(mintBootstrapScopes)
+		bootstrapToken, err := svc.MintBootstrapToken(cmd.Context(), mintBootstrapServiceID, mintBootstrapTarget, scopes, mintBootstrapTTL)
+		if err != nil {
+			return fmt.Errorf("failed to mint bootstrap token: %w", err)
+		}
+
+		fmt.Println(bootstrapToken)
+		return nil
+	},
+}
+
+func parseScopeCSV(scopesCSV string) []string {
+	if strings.TrimSpace(scopesCSV) == "" {
+		return nil
+	}
+
+	scopes := strings.Split(scopesCSV, ",")
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func init() {
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapPrivateKey, "key-file", "", "Path to RSA private key file used for signing")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapServiceID, "service-id", "", "Caller service identity to embed in subject")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapTarget, "target-service", "", "Target service audience allowed by the bootstrap token")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapScopes, "scopes", "", "Comma-separated scopes allowed for service token exchange")
+	mintBootstrapTokenCmd.Flags().DurationVar(&mintBootstrapTTL, "ttl", 5*time.Minute, "Bootstrap token lifetime")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapIssuer, "issuer", "http://tokensmith:8080", "Bootstrap token issuer")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapClusterID, "cluster-id", "cl-F00F00F00", "Cluster identifier claim")
+	mintBootstrapTokenCmd.Flags().StringVar(&mintBootstrapOpenCHAMIID, "openchami-id", "oc-F00F00F00", "OpenCHAMI identifier claim")
+
+	rootCmd.AddCommand(mintBootstrapTokenCmd)
+}

--- a/cmd/tokenservice/serve.go
+++ b/cmd/tokenservice/serve.go
@@ -31,17 +31,21 @@ var serveCmd = &cobra.Command{
 		if oidcClientSecret == "" {
 			oidcClientSecret = os.Getenv("OIDC_CLIENT_SECRET")
 		}
+		if bootstrapJTIStorePath == "" {
+			bootstrapJTIStorePath = os.Getenv("TOKENSMITH_BOOTSTRAP_JTI_STORE")
+		}
 
 		// Create token service configuration
 		serviceConfig := tokenservice.Config{
-			Issuer:           issuer,
-			GroupScopes:      fileConfig.GroupScopes, // Keep for backward compatibility
-			ClusterID:        clusterID,
-			OpenCHAMIID:      openCHAMIID,
-			NonEnforcing:     nonEnforcing,
-			OIDCIssuerURL:    oidcIssuerURL,
-			OIDCClientID:     oidcClientID,
-			OIDCClientSecret: oidcClientSecret,
+			Issuer:                issuer,
+			GroupScopes:           fileConfig.GroupScopes, // Keep for backward compatibility
+			ClusterID:             clusterID,
+			OpenCHAMIID:           openCHAMIID,
+			NonEnforcing:          nonEnforcing,
+			BootstrapJTIStorePath: bootstrapJTIStorePath,
+			OIDCIssuerURL:         oidcIssuerURL,
+			OIDCClientID:          oidcClientID,
+			OIDCClientSecret:      oidcClientSecret,
 		}
 
 		// Create key manager
@@ -77,7 +81,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		// Create token service
-		service, err := tokenservice.NewTokenService(nil, serviceConfig)
+		service, err := tokenservice.NewTokenService(keyManager, serviceConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create token service: %w", err)
 		}
@@ -98,6 +102,7 @@ func init() {
 	serveCmd.Flags().StringVar(&oidcClientSecret, "oidc-client-secret", "", "OIDC client secret (or set OIDC_CLIENT_SECRET env var)")
 	serveCmd.Flags().StringVar(&keyFile, "key-file", "", "Path to private key file")
 	serveCmd.Flags().StringVar(&keyDir, "key-dir", "", "Directory to save key files")
+	serveCmd.Flags().StringVar(&bootstrapJTIStorePath, "bootstrap-jti-store", "", "Path to file-backed consumed bootstrap JTI store (or set TOKENSMITH_BOOTSTRAP_JTI_STORE)")
 	serveCmd.Flags().BoolVar(&nonEnforcing, "non-enforcing", false, "Skip validation checks and only log errors")
 
 	rootCmd.AddCommand(serveCmd)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,6 +11,7 @@ This page documents the current `tokensmith` command surface in `cmd/tokenservic
 ## Commands
 
 - `tokensmith generate-config`
+- `tokensmith mint-bootstrap-token`
 - `tokensmith serve`
 
 Global flag:
@@ -46,6 +47,7 @@ Starts the token service.
 | `--oidc-client-secret` | OIDC client secret (or `OIDC_CLIENT_SECRET`) | `""` |
 | `--key-file` | Existing private key path | `""` |
 | `--key-dir` | Directory where generated keys are saved | `""` |
+| `--bootstrap-jti-store` | File path for consumed bootstrap-token JTIs (or `TOKENSMITH_BOOTSTRAP_JTI_STORE`) | `""` |
 | `--non-enforcing` | Skip strict validation checks and log errors | `false` |
 | `--config` | Path to JSON config file | `""` |
 
@@ -63,6 +65,38 @@ tokensmith serve \
   --key-dir ./keys \
   --oidc-issuer https://issuer.example \
   --oidc-client-id your-client-id
+```
+
+## `tokensmith mint-bootstrap-token`
+
+Mints a short-lived one-time bootstrap token for a caller service.
+
+This token is intended to be injected into a caller service process via environment variable and redeemed once at TokenSmith `/service/token` to obtain a regular service JWT.
+
+Reusing the same bootstrap token is denied. To obtain another service JWT later, mint and provision a new bootstrap token.
+
+### Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--key-file` | RSA private key path used to sign bootstrap token | `""` (required) |
+| `--service-id` | Caller service identity (`sub`) | `""` (required) |
+| `--target-service` | Allowed target service for exchange | `""` (required) |
+| `--scopes` | Comma-separated allowed scopes | `""` |
+| `--ttl` | Bootstrap token lifetime | `5m` |
+| `--issuer` | Bootstrap token issuer | `http://tokensmith:8080` |
+| `--cluster-id` | Cluster identifier claim | `cl-F00F00F00` |
+| `--openchami-id` | OpenCHAMI identifier claim | `oc-F00F00F00` |
+
+### Example
+
+```bash
+BOOTSTRAP_TOKEN=$(tokensmith mint-bootstrap-token \
+  --key-file ./keys/private.pem \
+  --service-id example-service-1 \
+  --target-service metadata-service \
+  --scopes read \
+  --ttl 5m)
 ```
 
 ## Configuration file schema

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -14,6 +14,7 @@ This page lists environment variables currently used by TokenSmith code paths.
 | --- | --- | --- |
 | `OIDC_CLIENT_ID` | `cmd/tokenservice/serve.go` | Fallback value for `--oidc-client-id` |
 | `OIDC_CLIENT_SECRET` | `cmd/tokenservice/serve.go` | Fallback value for `--oidc-client-secret` |
+| `TOKENSMITH_BOOTSTRAP_JTI_STORE` | `cmd/tokenservice/serve.go` | Fallback value for `--bootstrap-jti-store` path |
 
 Precedence:
 
@@ -39,6 +40,12 @@ Notes:
 
 - Cache behavior and policy semantics are still determined by mode and route mapping.
 - `policy_version` remains the authoritative hash of effective model/policy/grouping inputs.
+
+## Service-client variables
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `TOKENSMITH_BOOTSTRAP_TOKEN` | `pkg/tokenservice/client.go` | One-time startup bootstrap token redeemed at `POST /service/token` |
 
 ## Example-only variables
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,6 +35,36 @@ If `--oidc-client-id` or `--oidc-client-secret` are not provided, TokenSmith fal
 
 See full command options in `docs/cli-reference.md`.
 
+## 1.5) Internal service-to-service only (no external user token exchange)
+
+Standalone quick guide:
+
+- `docs/internal-service-auth.md`
+
+If your service only needs internal service-to-service AuthN/AuthZ, you can skip user token exchange flows and use this path:
+
+1. Mint a one-time bootstrap token before service startup using `tokensmith mint-bootstrap-token`.
+2. Pass bootstrap token via `TOKENSMITH_BOOTSTRAP_TOKEN` to the caller service process.
+3. Have the caller service redeem bootstrap token(s) for service JWTs using:
+  - `pkg/tokenservice` (library), or
+  - `example/serviceauth` (end-to-end client example).
+4. In the target service, install TokenSmith AuthN middleware to validate JWTs and build a verified principal.
+5. Install TokenSmith AuthZ middleware and map routes using either:
+  - explicit `authz.RouteMapper`, or
+  - path/method style (`authz.PathMethodMapper` + Casbin matchers).
+6. Ensure service principals map to the `service` role in policy/grouping.
+
+Current examples:
+
+- `example/serviceauth` (service token acquisition/refresh)
+- `examples/minisvc/main.go` (AuthN + AuthZ middleware wiring)
+- `examples/minisvc/policy/` (Casbin model/policy/grouping)
+
+Normative requirements for service principals:
+
+- `docs/authz_contract.md#service-principal-requirements`
+- `docs/authz_contract.md#integration-checklist-services`
+
 ## 2) Pick an AuthZ integration style
 
 TokenSmith supports two common patterns:

--- a/docs/internal-service-auth.md
+++ b/docs/internal-service-auth.md
@@ -1,0 +1,130 @@
+<!--
+Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+
+SPDX-License-Identifier: MIT
+-->
+
+# Internal service-to-service AuthN/AuthZ
+
+This guide is for services that only need **internal service-to-service** authentication and authorization.
+
+Use this when:
+
+- clients are other trusted services (not end users)
+- caller services obtain service JWTs from TokenSmith
+- target services enforce JWT AuthN + Casbin AuthZ via TokenSmith middleware
+
+For normative wire behavior and contract details, see:
+
+- `docs/authz-spec.md`
+- `docs/authz_contract.md`
+
+## 1) Caller service: obtain service tokens from bootstrap token
+
+Use `pkg/tokenservice` in the caller service to redeem startup bootstrap tokens for service JWTs.
+
+Canonical exchange endpoint:
+
+- `POST /service/token`
+
+Canonical request body:
+
+```json
+{
+	"bootstrap_token": "<jwt>",
+	"target_service": "metadata-service",
+	"scopes": ["read"]
+}
+```
+
+Notes:
+
+- `target_service` and `scopes` are optional in the request body.
+- If omitted, TokenSmith uses the allowed target/scopes embedded in the bootstrap token.
+
+Canonical response body:
+
+```json
+{
+	"token": "<service-jwt>",
+	"expires_at": "2026-03-25T18:47:12Z"
+}
+```
+
+### Bootstrap mint and distribution
+
+1. Mint a short-lived one-time bootstrap token before service startup:
+
+```bash
+BOOTSTRAP_TOKEN=$(tokensmith mint-bootstrap-token \
+	--key-file ./keys/private.pem \
+	--service-id example-service-1 \
+	--target-service metadata-service \
+	--scopes read \
+	--ttl 5m)
+```
+
+2. Start the caller service with:
+
+```bash
+export TOKENSMITH_BOOTSTRAP_TOKEN="$BOOTSTRAP_TOKEN"
+```
+
+3. Caller redeems this token once at `POST /service/token` and receives a regular service JWT for S2S calls.
+
+4. TokenSmith enforces one-time use using bootstrap-token `jti` tracking.
+5. For restart-safe replay protection, start TokenSmith with `--bootstrap-jti-store /path/to/bootstrap-jti.json` (or `TOKENSMITH_BOOTSTRAP_JTI_STORE`).
+6. If a caller needs a new service JWT after bootstrap consumption, provision a new bootstrap token and update `TOKENSMITH_BOOTSTRAP_TOKEN` before requesting again.
+
+Reference implementation:
+
+- `example/serviceauth/README.md`
+- `example/serviceauth/main.go`
+
+## 2) Target service: validate JWTs and enforce policy
+
+Install middleware in this order:
+
+1. TokenSmith AuthN middleware (JWT validation + principal extraction)
+2. TokenSmith AuthZ middleware (Casbin decision)
+
+Reference wiring:
+
+- `examples/minisvc/main.go`
+- `examples/minisvc/mapper.go`
+
+## 3) Policy and role mapping
+
+Ensure service principals map to role `service` in policy/grouping. The baseline role model includes `service` for service-to-service calls.
+
+Reference files:
+
+- `examples/minisvc/policy/model.conf`
+- `examples/minisvc/policy/policy.csv`
+- `examples/minisvc/policy/grouping.csv`
+
+Normative requirements:
+
+- `docs/authz_contract.md#service-principal-requirements`
+- `docs/authz_contract.md#rbac-role-model-minimum-required-roles`
+
+## 4) Rollout mode
+
+Roll out per service using:
+
+1. `off`
+2. `shadow`
+3. `enforce`
+
+Operational guidance:
+
+- `docs/authz_operations.md`
+
+## 5) Recommended integration checklist
+
+- Caller receives `TOKENSMITH_BOOTSTRAP_TOKEN` at startup and redeems once via `pkg/tokenservice`
+- Target installs AuthN before AuthZ
+- Routes are mapped via `authz.RouteMapper` or path/method mapping
+- Service principals resolve to role `service`
+- Service runs through off → shadow → enforce rollout
+- Operators track `policy_version` in logs/deny responses

--- a/example/hydra/go.mod
+++ b/example/hydra/go.mod
@@ -15,17 +15,18 @@ require (
 )
 
 require (
-	github.com/MicahParks/keyfunc v1.9.0 // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
+	github.com/MicahParks/keyfunc/v3 v3.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/govaluate v1.3.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 )
 
 replace github.com/openchami/tokensmith => ../../

--- a/example/hydra/go.sum
+++ b/example/hydra/go.sum
@@ -1,5 +1,7 @@
-github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
-github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
@@ -12,8 +14,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
@@ -47,6 +47,8 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/example/middleware/go.mod
+++ b/example/middleware/go.mod
@@ -13,17 +13,18 @@ require (
 )
 
 require (
-	github.com/MicahParks/keyfunc v1.9.0 // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
+	github.com/MicahParks/keyfunc/v3 v3.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/govaluate v1.3.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/openchami/tokensmith v0.0.0 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 )
 
 replace github.com/openchami/tokensmith/middleware => ../../middleware

--- a/example/middleware/go.sum
+++ b/example/middleware/go.sum
@@ -1,5 +1,7 @@
-github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
-github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
@@ -12,8 +14,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
@@ -47,6 +47,8 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/example/serviceauth/README.md
+++ b/example/serviceauth/README.md
@@ -7,9 +7,8 @@ SPDX-License-Identifier: MIT
 # Service Authentication Example
 
 This example demonstrates how to implement service-to-service authentication using the tokensmith service. It shows how a service can:
-1. Obtain a service token from tokensmith
-2. Automatically refresh the token when needed
-3. Use the token to authenticate with other services
+1. Redeem a startup bootstrap token for a service token from TokenSmith
+2. Use the token to authenticate with other services
 
 ## Prerequisites
 
@@ -22,7 +21,11 @@ This example demonstrates how to implement service-to-service authentication usi
 Before running the example, you need to:
 
 1. Ensure the tokensmith service is running and accessible
-2. Update the following constants in `main.go` if needed:
+2. Export a bootstrap token:
+   ```bash
+   export TOKENSMITH_BOOTSTRAP_TOKEN="<one-time-bootstrap-jwt>"
+   ```
+3. Update the following constants in `main.go` if needed:
    ```go
    const (
        tokensmithURL = "http://localhost:8080" // Your tokensmith service URL
@@ -30,7 +33,7 @@ Before running the example, you need to:
        serviceID     = "example-service-1"      // Your service ID
    )
    ```
-3. Update the `targetURL` in the main function to point to your target service:
+4. Update the `targetURL` in the main function to point to your target service:
    ```go
    targetURL := "http://localhost:8081/protected-endpoint"
    ```
@@ -48,22 +51,22 @@ Before running the example, you need to:
    ```
 
 The example will:
-1. Get an initial service token from tokensmith with OpenCHAMI-specific claims
+1. Redeem the bootstrap token and get an initial service token from tokensmith
 2. Display the token expiration time
-3. Demonstrate token refresh functionality
+3. Demonstrate refresh check behavior
 4. Use the token to call another service
 
 ## OpenCHAMI Integration
 
-This example uses the `tokenservice` package from tokensmith to handle service authentication. The service tokens include OpenCHAMI-specific custom claims:
+This example uses the `tokenservice` package from tokensmith to handle service authentication. The service tokens include OpenCHAMI-specific custom claims configured on the TokenSmith server:
 
-- `instance_id`: The OpenCHAMI instance identifier
+- `openchami_id`: The OpenCHAMI instance identifier
 - `cluster_id`: The OpenCHAMI cluster identifier
 - `iss`: The tokensmith service URI as the issuer
 
-These claims are passed via headers:
-- `X-Instance-ID`: OpenCHAMI instance identifier
-- `X-Cluster-ID`: OpenCHAMI cluster identifier
+The startup bootstrap token is passed via environment variable:
+
+- `TOKENSMITH_BOOTSTRAP_TOKEN`: one-time bootstrap JWT redeemed at `POST /service/token`
 
 The tokensmith service will include these claims in the generated JWT tokens, which can be used for:
 - Service identification within OpenCHAMI
@@ -86,13 +89,13 @@ The example uses the `tokenservice` package from tokensmith, which provides:
    ```
 
 2. **Token Management**
-   - `GetToken()`: Obtains a new service token
-   - `RefreshTokenIfNeeded()`: Automatically refreshes the token when close to expiration
+   - `GetToken()`: Redeems the current bootstrap token and obtains a service token
+   - `RefreshTokenIfNeeded()`: Checks token lifetime and attempts to fetch a new token when close to expiration (requires a newly provisioned bootstrap token after one-time consumption)
    - `GetServiceToken()`: Retrieves the current service token
 
 3. **Service Communication**
    - `CallTargetService()`: Makes authenticated requests to other services
-   - Automatic token refresh before making requests
+   - Token lifetime check before making requests
    - Proper error handling and context management
 
 ## Error Handling
@@ -106,7 +109,7 @@ The example includes comprehensive error handling for:
 
 ## Security Considerations
 
-- Tokens are automatically refreshed when they're close to expiration
+- Bootstrap tokens are one-time use; after redemption, obtaining another service token requires provisioning a new bootstrap token
 - All HTTP requests use HTTPS in production (update URLs accordingly)
 - Context timeouts are used to prevent hanging requests
 - Service credentials are managed securely through the tokenservice package

--- a/middleware/go.mod
+++ b/middleware/go.mod
@@ -7,7 +7,7 @@ module github.com/openchami/tokensmith/middleware
 go 1.24.0
 
 require (
-	github.com/MicahParks/keyfunc v1.9.0
+	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/openchami/tokensmith v0.0.0
 	github.com/rs/zerolog v1.34.0
@@ -15,13 +15,14 @@ require (
 )
 
 require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/casbin/govaluate v1.3.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 )
 
 require (

--- a/middleware/go.sum
+++ b/middleware/go.sum
@@ -1,5 +1,7 @@
-github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
-github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
@@ -10,8 +12,6 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
@@ -45,6 +45,8 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -6,14 +6,16 @@ package middleware
 
 import (
 	"context"
+	"crypto"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/MicahParks/keyfunc"
+	"github.com/MicahParks/keyfunc/v3"
 	"github.com/casbin/casbin/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/openchami/tokensmith/pkg/keys"
@@ -243,17 +245,48 @@ func JWTMiddleware(key interface{}, opts *MiddlewareOptions) func(http.Handler) 
 
 // refresh fetches and updates the JWKS cache (expects JWKS as a map of kid to key)
 func (c *keySetCache) refresh(url string) error {
-	jwks, err := keyfunc.Get(url, keyfunc.Options{})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("jwks fetch failed: status=%d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+
+	kf, err := keyfunc.NewJWKSetJSON(body)
+	if err != nil {
+		return err
+	}
+
+	jwksKeys, err := kf.Storage().KeyReadAll(context.Background())
 	if err != nil {
 		return err
 	}
 
 	newKeySet := make(map[string]interface{})
-	for kid, key := range jwks.ReadOnlyKeys() {
-		if key == nil {
+	for _, jwk := range jwksKeys {
+		m := jwk.Marshal()
+		if m.KID == "" {
 			continue
 		}
-		newKeySet[kid] = key
+
+		pub, ok := jwk.Key().(crypto.PublicKey)
+		if !ok {
+			continue
+		}
+
+		newKeySet[m.KID] = pub
 	}
 
 	c.mu.Lock()

--- a/pkg/tokenservice/client.go
+++ b/pkg/tokenservice/client.go
@@ -5,11 +5,13 @@
 package tokenservice
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -49,16 +51,22 @@ func (c *ServiceClient) GetServiceToken() *ServiceToken {
 
 // GetToken obtains a new service token from tokensmith
 func (c *ServiceClient) GetToken(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/v1/service/token", c.tokensmithURL), nil)
+	bodyBytes, err := json.Marshal(ServiceTokenRequest{
+		BootstrapToken: os.Getenv(BootstrapTokenEnvVar),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to encode token request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/service/token", c.tokensmithURL), bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
-	// Add service authentication headers
-	req.Header.Set("X-Service-Name", c.serviceName)
-	req.Header.Set("X-Service-ID", c.serviceID)
-	req.Header.Set("X-Instance-ID", c.instanceID)
-	req.Header.Set("X-Cluster-ID", c.clusterID)
+	if os.Getenv(BootstrapTokenEnvVar) == "" {
+		return fmt.Errorf("missing %s environment variable", BootstrapTokenEnvVar)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -73,12 +81,12 @@ func (c *ServiceClient) GetToken(ctx context.Context) error {
 		return fmt.Errorf("failed to get token: status=%d, body=%s", resp.StatusCode, string(body))
 	}
 
-	var token ServiceToken
+	var token ServiceTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
 		return fmt.Errorf("failed to decode token response: %w", err)
 	}
 
-	c.token = &token
+	c.token = &ServiceToken{Token: token.Token, ExpiresAt: token.ExpiresAt}
 	return nil
 }
 

--- a/pkg/tokenservice/service.go
+++ b/pkg/tokenservice/service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -38,11 +39,12 @@ const (
 
 // Config holds the configuration for the token service
 type Config struct {
-	Issuer       string
-	GroupScopes  map[string][]string
-	ClusterID    string
-	OpenCHAMIID  string
-	NonEnforcing bool // Skip validation checks and only log errors
+	Issuer                string
+	GroupScopes           map[string][]string
+	ClusterID             string
+	OpenCHAMIID           string
+	NonEnforcing          bool // Skip validation checks and only log errors
+	BootstrapJTIStorePath string
 
 	// OIDC provider configuration
 	OIDCIssuerURL    string
@@ -60,6 +62,8 @@ type TokenService struct {
 	OpenCHAMIID  string
 	OIDCProvider oidc.Provider
 	mu           sync.RWMutex
+	bootstrapMu  sync.Mutex
+	usedBootJTI  map[string]time.Time
 }
 
 // NewTokenService creates a new TokenService instance
@@ -80,7 +84,7 @@ func NewTokenService(keyManager *keys.KeyManager, config Config) (*TokenService,
 		config.OIDCClientSecret,
 	)
 
-	return &TokenService{
+	svc := &TokenService{
 		TokenManager: tokenManager,
 		Config:       config,
 		Issuer:       config.Issuer,
@@ -88,7 +92,58 @@ func NewTokenService(keyManager *keys.KeyManager, config Config) (*TokenService,
 		ClusterID:    config.ClusterID,
 		OpenCHAMIID:  config.OpenCHAMIID,
 		OIDCProvider: oidcProvider,
-	}, nil
+		usedBootJTI:  map[string]time.Time{},
+	}
+
+	if err := svc.loadBootstrapJTIStore(); err != nil {
+		return nil, fmt.Errorf("failed to load bootstrap jti store: %w", err)
+	}
+
+	return svc, nil
+}
+
+// MintBootstrapToken creates a short-lived bootstrap token intended for one-time
+// exchange at /service/token to obtain a standard service token.
+func (s *TokenService) MintBootstrapToken(ctx context.Context, serviceID, targetService string, scopes []string, ttl time.Duration) (string, error) {
+	if serviceID == "" {
+		return "", errors.New("service ID cannot be empty")
+	}
+	if targetService == "" {
+		return "", errors.New("target service cannot be empty")
+	}
+	if ttl <= 0 {
+		return "", errors.New("ttl must be greater than zero")
+	}
+
+	now := time.Now()
+	claims := &token.TSClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    s.Issuer,
+			Subject:   serviceID,
+			Audience:  []string{BootstrapAudience},
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+			NotBefore: jwt.NewNumericDate(now),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+		ClusterID:   s.ClusterID,
+		OpenCHAMIID: s.OpenCHAMIID,
+		Scope:       append([]string(nil), scopes...),
+		AuthLevel:   "IAL2",
+		AuthFactors: 2,
+		AuthMethods: []string{"bootstrap", "offline"},
+		SessionID:   fmt.Sprintf("bootstrap-%s-%d", serviceID, now.UnixNano()),
+		SessionExp:  now.Add(ttl).Unix(),
+		AuthEvents:  []string{"bootstrap_mint"},
+	}
+
+	additionalClaims := map[string]interface{}{
+		BootstrapTokenUseField: BootstrapTokenUseClaim,
+		BootstrapTargetField:   targetService,
+		BootstrapScopesField:   append([]string(nil), scopes...),
+		BootstrapOneTimeField:  true,
+	}
+
+	return s.TokenManager.GenerateTokenWithClaims(claims, additionalClaims)
 }
 
 // ExchangeToken exchanges an external token for an internal token
@@ -400,79 +455,254 @@ func (s *TokenService) ServiceTokenHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Verify the request is from an authorized service
-	serviceID, err := s.authenticateService(r)
-	if err != nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-
-	// Parse request body
-	var req struct {
-		TargetService string   `json:"target_service"`
-		Scopes        []string `json:"scopes"`
-	}
+	// Parse canonical request body.
+	var req ServiceTokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
+	serviceID, targetService, effectiveScopes, err := s.authenticateBootstrapRequest(req)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	// Validate target service and scopes
-	if err := s.validateServiceRequest(serviceID, req.TargetService, req.Scopes); err != nil {
+	if err := s.validateServiceRequest(serviceID, targetService, effectiveScopes); err != nil {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 
 	// Generate service token
-	token, err := s.GenerateServiceToken(r.Context(), serviceID, req.TargetService, req.Scopes)
+	tokenValue, err := s.GenerateServiceToken(r.Context(), serviceID, targetService, effectiveScopes)
 	if err != nil {
 		http.Error(w, "Failed to generate token", http.StatusInternalServerError)
 		return
 	}
 
+	claims, _, err := s.TokenManager.ParseToken(tokenValue)
+	if err != nil {
+		http.Error(w, "Failed to validate generated token", http.StatusInternalServerError)
+		return
+	}
+
 	// Return token
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"access_token": token,
-		"token_type":   "Bearer",
+	_ = json.NewEncoder(w).Encode(ServiceTokenResponse{
+		Token:     tokenValue,
+		ExpiresAt: claims.ExpiresAt.Time,
 	})
 }
 
-// authenticateService verifies that the request is from an authorized service
-func (s *TokenService) authenticateService(r *http.Request) (string, error) {
-	// This could be implemented using:
-	// 1. Mutual TLS (mTLS) certificates
-	// 2. API keys in headers
-	// 3. Service-specific authentication tokens
-	// Example using API key:
-	apiKey := r.Header.Get("X-Service-API-Key")
-	if apiKey == "" {
-		return "", errors.New("missing service API key")
+func (s *TokenService) authenticateBootstrapRequest(req ServiceTokenRequest) (string, string, []string, error) {
+	if strings.TrimSpace(req.BootstrapToken) == "" {
+		return "", "", nil, errors.New("missing bootstrap token")
 	}
 
-	// Validate API key and return service ID
-	serviceID, err := s.validateServiceAPIKey(apiKey)
+	claims, _, err := s.TokenManager.ParseToken(req.BootstrapToken)
 	if err != nil {
-		return "", err
+		return "", "", nil, fmt.Errorf("invalid bootstrap token: %w", err)
 	}
 
-	return serviceID, nil
+	var rawClaims map[string]interface{}
+	rawClaims, err = s.parseRawMapClaims(req.BootstrapToken)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("invalid bootstrap token claims: %w", err)
+	}
+
+	if claims.Subject == "" {
+		return "", "", nil, errors.New("bootstrap token subject is required")
+	}
+
+	tokenUse, _ := rawClaims[BootstrapTokenUseField].(string)
+	if tokenUse != BootstrapTokenUseClaim {
+		return "", "", nil, errors.New("invalid bootstrap token use")
+	}
+
+	allowedTarget, _ := rawClaims[BootstrapTargetField].(string)
+	if strings.TrimSpace(allowedTarget) == "" {
+		return "", "", nil, errors.New("bootstrap token target_service is required")
+	}
+
+	requestedTarget := strings.TrimSpace(req.TargetService)
+	if requestedTarget == "" {
+		requestedTarget = allowedTarget
+	}
+	if requestedTarget != allowedTarget {
+		return "", "", nil, errors.New("requested target service does not match bootstrap token")
+	}
+
+	allowedScopes := extractStringSliceClaim(rawClaims, BootstrapScopesField)
+	if len(allowedScopes) == 0 {
+		allowedScopes = append([]string(nil), claims.Scope...)
+	}
+
+	effectiveScopes := append([]string(nil), req.Scopes...)
+	if len(effectiveScopes) == 0 {
+		effectiveScopes = append([]string(nil), allowedScopes...)
+	}
+
+	if !isSubset(effectiveScopes, allowedScopes) {
+		return "", "", nil, errors.New("requested scopes exceed bootstrap token scopes")
+	}
+
+	if err := s.consumeBootstrapJTI(claims.ID); err != nil {
+		return "", "", nil, err
+	}
+
+	return claims.Subject, requestedTarget, effectiveScopes, nil
+}
+
+func (s *TokenService) consumeBootstrapJTI(jti string) error {
+	jti = strings.TrimSpace(jti)
+	if jti == "" {
+		return errors.New("bootstrap token missing jti")
+	}
+
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+
+	if s.usedBootJTI == nil {
+		s.usedBootJTI = map[string]time.Time{}
+	}
+
+	if _, exists := s.usedBootJTI[jti]; exists {
+		return errors.New("bootstrap token already consumed")
+	}
+
+	s.usedBootJTI[jti] = time.Now()
+	if err := s.persistBootstrapJTIStoreLocked(); err != nil {
+		delete(s.usedBootJTI, jti)
+		return fmt.Errorf("failed to persist bootstrap token consumption: %w", err)
+	}
+	return nil
+}
+
+func (s *TokenService) loadBootstrapJTIStore() error {
+	path := strings.TrimSpace(s.Config.BootstrapJTIStorePath)
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	loaded := map[string]time.Time{}
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		return err
+	}
+
+	for jti, seenAt := range loaded {
+		s.usedBootJTI[jti] = seenAt
+	}
+
+	return nil
+}
+
+func (s *TokenService) persistBootstrapJTIStoreLocked() error {
+	path := strings.TrimSpace(s.Config.BootstrapJTIStorePath)
+	if path == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(s.usedBootJTI, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0600)
+}
+
+func extractStringSliceClaim(rawClaims map[string]interface{}, key string) []string {
+	v, ok := rawClaims[key]
+	if !ok {
+		return nil
+	}
+
+	slice, ok := v.([]interface{})
+	if !ok {
+		if direct, ok := v.([]string); ok {
+			return append([]string(nil), direct...)
+		}
+		return nil
+	}
+
+	out := make([]string, 0, len(slice))
+	for _, item := range slice {
+		if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+func isSubset(requested, allowed []string) bool {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, scope := range allowed {
+		scope = strings.TrimSpace(scope)
+		if scope != "" {
+			allowedSet[scope] = struct{}{}
+		}
+	}
+
+	for _, scope := range requested {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if _, ok := allowedSet[scope]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 // validateServiceRequest checks if a service is allowed to request tokens for the target service
 func (s *TokenService) validateServiceRequest(serviceID, targetService string, scopes []string) error {
+	if serviceID == "" {
+		return errors.New("service ID is required")
+	}
+	if targetService == "" {
+		return errors.New("target service is required")
+	}
+
+	if len(scopes) == 0 {
+		return nil
+	}
+
 	// Implement service-to-service authorization rules
 	// This could be based on:
 	// 1. Pre-configured service relationships
 	// 2. Dynamic service discovery
 	// 3. Service mesh configuration
 	allowedTargets := s.getServiceAllowedTargets(serviceID)
+	if len(allowedTargets) == 0 {
+		return nil
+	}
 	if !allowedTargets[targetService] {
 		return fmt.Errorf("service %s is not allowed to request tokens for %s", serviceID, targetService)
 	}
 
 	// Validate requested scopes
 	allowedScopes := s.getServiceAllowedScopes(serviceID, targetService)
+	if len(allowedScopes) == 0 {
+		return nil
+	}
 	for _, scope := range scopes {
 		if !allowedScopes[scope] {
 			return fmt.Errorf("service %s is not allowed to request scope %s for %s",
@@ -483,32 +713,42 @@ func (s *TokenService) validateServiceRequest(serviceID, targetService string, s
 	return nil
 }
 
-// validateServiceAPIKey validates a service API key and returns the service ID
-func (s *TokenService) validateServiceAPIKey(apiKey string) (string, error) {
-	// TODO: Implement API key validation
-	// This should be replaced with actual API key validation logic
-	// For now, we'll just return a mock service ID
-	return "mock-service", nil
-}
-
 // getServiceAllowedTargets returns the list of services that a given service is allowed to request tokens for
 func (s *TokenService) getServiceAllowedTargets(serviceID string) map[string]bool {
 	// TODO: Implement service target validation
 	// This should be replaced with actual service relationship logic
-	// For now, we'll just return a mock allowed target
-	return map[string]bool{
-		"mock-target": true,
-	}
+	// For now, return empty map and allow target validation to be driven by
+	// bootstrap token claims.
+	return map[string]bool{}
 }
 
 // getServiceAllowedScopes returns the list of scopes that a given service is allowed to request for a target service
 func (s *TokenService) getServiceAllowedScopes(serviceID, targetService string) map[string]bool {
 	// TODO: Implement scope validation
 	// This should be replaced with actual scope validation logic
-	// For now, we'll just return a mock allowed scope
-	return map[string]bool{
-		"mock-scope": true,
+	// For now, return empty map and allow scope validation to be driven by
+	// bootstrap token claims.
+	return map[string]bool{}
+}
+
+func (s *TokenService) parseRawMapClaims(tokenString string) (map[string]interface{}, error) {
+	publicKey, err := s.TokenManager.GetKeyManager().GetPublicKey()
+	if err != nil {
+		return nil, err
 	}
+
+	mapClaims := jwt.MapClaims{}
+	parsedToken, err := jwt.ParseWithClaims(tokenString, mapClaims, func(token *jwt.Token) (interface{}, error) {
+		return publicKey, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !parsedToken.Valid {
+		return nil, errors.New("token is invalid")
+	}
+
+	return mapClaims, nil
 }
 
 // HealthHandler provides a health check endpoint

--- a/pkg/tokenservice/service_test.go
+++ b/pkg/tokenservice/service_test.go
@@ -5,10 +5,14 @@
 package tokenservice
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -534,4 +538,128 @@ func TestTokenService_ValidateToken(t *testing.T) {
 			tt.validateClaims(t, claims)
 		})
 	}
+}
+
+func TestTokenService_ServiceTokenHandler_BootstrapExchange(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyManager := keys.NewKeyManager()
+	err = keyManager.SetKeyPair(privateKey, &privateKey.PublicKey)
+	require.NoError(t, err)
+
+	service, err := NewTokenService(keyManager, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-a",
+		OpenCHAMIID: "openchami-a",
+	})
+	require.NoError(t, err)
+
+	bootstrapToken, err := service.MintBootstrapToken(context.Background(), "svc-a", "svc-b", []string{"read", "write"}, 5*time.Minute)
+	require.NoError(t, err)
+
+	reqBody := ServiceTokenRequest{
+		BootstrapToken: bootstrapToken,
+		TargetService:  "svc-b",
+		Scopes:         []string{"read"},
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/service/token", bytes.NewReader(bodyBytes))
+	w := httptest.NewRecorder()
+
+	service.ServiceTokenHandler(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp ServiceTokenResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+	require.NotEmpty(t, tokenResp.Token)
+	require.False(t, tokenResp.ExpiresAt.IsZero())
+
+	claims, _, err := service.TokenManager.ParseToken(tokenResp.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "svc-a", claims.Subject)
+	assert.Equal(t, []string{"svc-b"}, []string(claims.Audience))
+	assert.Equal(t, []string{"read"}, claims.Scope)
+}
+
+func TestTokenService_ServiceTokenHandler_BootstrapTokenReuseDenied(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyManager := keys.NewKeyManager()
+	err = keyManager.SetKeyPair(privateKey, &privateKey.PublicKey)
+	require.NoError(t, err)
+
+	service, err := NewTokenService(keyManager, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-a",
+		OpenCHAMIID: "openchami-a",
+	})
+	require.NoError(t, err)
+
+	bootstrapToken, err := service.MintBootstrapToken(context.Background(), "svc-a", "svc-b", []string{"read"}, 5*time.Minute)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(ServiceTokenRequest{BootstrapToken: bootstrapToken})
+	require.NoError(t, err)
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/service/token", bytes.NewReader(body))
+	firstW := httptest.NewRecorder()
+	service.ServiceTokenHandler(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Result().StatusCode)
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/service/token", bytes.NewReader(body))
+	secondW := httptest.NewRecorder()
+	service.ServiceTokenHandler(secondW, secondReq)
+	require.Equal(t, http.StatusUnauthorized, secondW.Result().StatusCode)
+}
+
+func TestTokenService_ServiceTokenHandler_BootstrapTokenReuseDeniedAfterRestart(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	storePath := filepath.Join(t.TempDir(), "bootstrap-used-jti.json")
+
+	keyManagerA := keys.NewKeyManager()
+	err = keyManagerA.SetKeyPair(privateKey, &privateKey.PublicKey)
+	require.NoError(t, err)
+
+	serviceA, err := NewTokenService(keyManagerA, Config{
+		Issuer:                "http://tokensmith.test",
+		ClusterID:             "cluster-a",
+		OpenCHAMIID:           "openchami-a",
+		BootstrapJTIStorePath: storePath,
+	})
+	require.NoError(t, err)
+
+	bootstrapToken, err := serviceA.MintBootstrapToken(context.Background(), "svc-a", "svc-b", []string{"read"}, 5*time.Minute)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(ServiceTokenRequest{BootstrapToken: bootstrapToken})
+	require.NoError(t, err)
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/service/token", bytes.NewReader(body))
+	firstW := httptest.NewRecorder()
+	serviceA.ServiceTokenHandler(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Result().StatusCode)
+
+	keyManagerB := keys.NewKeyManager()
+	err = keyManagerB.SetKeyPair(privateKey, &privateKey.PublicKey)
+	require.NoError(t, err)
+
+	serviceB, err := NewTokenService(keyManagerB, Config{
+		Issuer:                "http://tokensmith.test",
+		ClusterID:             "cluster-a",
+		OpenCHAMIID:           "openchami-a",
+		BootstrapJTIStorePath: storePath,
+	})
+	require.NoError(t, err)
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/service/token", bytes.NewReader(body))
+	secondW := httptest.NewRecorder()
+	serviceB.ServiceTokenHandler(secondW, secondReq)
+	require.Equal(t, http.StatusUnauthorized, secondW.Result().StatusCode)
 }

--- a/pkg/tokenservice/service_token_contract.go
+++ b/pkg/tokenservice/service_token_contract.go
@@ -1,0 +1,31 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package tokenservice
+
+import "time"
+
+const (
+	BootstrapTokenUseClaim = "bootstrap_service"
+	BootstrapTokenUseField = "token_use"
+	BootstrapTargetField   = "target_service"
+	BootstrapScopesField   = "scopes"
+	BootstrapOneTimeField  = "bootstrap_one_time"
+	BootstrapAudience      = "tokensmith"
+	BootstrapTokenEnvVar   = "TOKENSMITH_BOOTSTRAP_TOKEN"
+)
+
+// ServiceTokenRequest is the canonical request payload for obtaining
+// a short-lived service token used in internal service-to-service calls.
+type ServiceTokenRequest struct {
+	BootstrapToken string   `json:"bootstrap_token"`
+	TargetService  string   `json:"target_service,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
+}
+
+// ServiceTokenResponse is the canonical response payload for service-token minting.
+type ServiceTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}


### PR DESCRIPTION
### Description

This pull request introduces a new workflow for internal service-to-service authentication and authorization (AuthN/AuthZ) using one-time bootstrap tokens in TokenSmith. The update adds a CLI command and supporting documentation for minting and redeeming bootstrap tokens, clarifies the recommended integration path for internal services, and enhances configuration options for secure token handling. The most important changes are grouped below.

**New CLI Command and Token Workflow**

* Added the `mint-bootstrap-token` command to the `tokensmith` CLI, allowing operators to mint one-time bootstrap tokens for service startup. This includes argument parsing, key loading, and token minting logic in `cmd/tokenservice/mint_bootstrap_token.go`, and registration in the CLI (`serve.go`, `README.md`, and `cli-reference.md`). [[1]](diffhunk://#diff-8d6fc7910b8c248efbf0f7bbd8835cf75e42540537f2c9453cf70f3974e770c4R1-R98) [[2]](diffhunk://#diff-d5d8360d1a358f2af4bbafbf521fa1a56bdd0b1bdf9bb397244d3bd650e7dd01R14) [[3]](diffhunk://#diff-d5d8360d1a358f2af4bbafbf521fa1a56bdd0b1bdf9bb397244d3bd650e7dd01R70-R101)
* Documented the new workflow for internal service-to-service authentication, including step-by-step instructions for minting, distributing, and redeeming bootstrap tokens, in the new `docs/internal-service-auth.md` and in `docs/getting-started.md`. [[1]](diffhunk://#diff-dc4b2a313536df5f1aa5b3613b315b7e990514ae80206de3c97790ba051dbf0aR1-R130) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R38-R67) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R50)

**Configuration and Environment Enhancements**

* Introduced the `--bootstrap-jti-store` flag and `TOKENSMITH_BOOTSTRAP_JTI_STORE` environment variable to persist consumed bootstrap token JTIs for replay protection, with corresponding updates in the CLI, environment variable documentation, and service startup logic (`serve.go`, `cli-reference.md`, `env-reference.md`). [[1]](diffhunk://#diff-b96f94e2e24a09390ac52fee378ad34b273987c383892db95bcc451d08639deeR26) [[2]](diffhunk://#diff-075b43de34d6432bc3790b48419549d46bd3f2819c58fd7f76c5fb3278baf31fR34-R36) [[3]](diffhunk://#diff-075b43de34d6432bc3790b48419549d46bd3f2819c58fd7f76c5fb3278baf31fR45) [[4]](diffhunk://#diff-075b43de34d6432bc3790b48419549d46bd3f2819c58fd7f76c5fb3278baf31fR105) [[5]](diffhunk://#diff-d5d8360d1a358f2af4bbafbf521fa1a56bdd0b1bdf9bb397244d3bd650e7dd01R50) [[6]](diffhunk://#diff-fa3613ed36ca921879243721f4557c97b36fb9894f3f30a11fffa7fe747e2375R17)

**Documentation and Example Updates**

* Updated the service authentication example (`example/serviceauth/README.md`) to use the new bootstrap token workflow, clarifying environment variable usage and removing outdated refresh logic. [[1]](diffhunk://#diff-3750811a65ddcd4fbfad49841447c0ac62e157cb4416862f44899ec728b911efL10-R11) [[2]](diffhunk://#diff-3750811a65ddcd4fbfad49841447c0ac62e157cb4416862f44899ec728b911efL25-R36) [[3]](diffhunk://#diff-3750811a65ddcd4fbfad49841447c0ac62e157cb4416862f44899ec728b911efL51-R69) [[4]](diffhunk://#diff-3750811a65ddcd4fbfad49841447c0ac62e157cb4416862f44899ec728b911efL89-R98)
* Added references to relevant documentation and example projects for both operators and developers, improving discoverability of the new service-to-service AuthN/AuthZ pattern. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R50) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R38-R67) [[3]](diffhunk://#diff-dc4b2a313536df5f1aa5b3613b315b7e990514ae80206de3c97790ba051dbf0aR1-R130)

**Dependency Updates**

* Updated example service dependencies to use newer versions of JWT and JWK libraries, and added `golang.org/x/time` as an indirect dependency. [[1]](diffhunk://#diff-27969690d38803f26e5426c11b5633c5f05b3ad43517d4201721ab932e027dd8L18-R29) [[2]](diffhunk://#diff-63146b664bcbcc26db59b0f5b52a46e5b0e9f4b920726ad8280cfc1f6169c2abL16-R27)

These changes collectively make it easier and more secure for internal services to authenticate and authorize using TokenSmith, with clear operational guidance and robust one-time token handling.


### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [\] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
