### PR TITLE
feat: Implement mTLS service identity support for token exchange

### DIFF
--- a/cmd/tokenservice/main.go
+++ b/cmd/tokenservice/main.go
@@ -27,6 +27,9 @@ var (
 	enableLocalUserMint       bool
 	rfc8693BootstrapStorePath string
 	rfc8693RefreshStorePath   string
+	serviceIdentityCAPath     string
+	tlsCertFile               string
+	tlsKeyFile                string
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/tokenservice/serve.go
+++ b/cmd/tokenservice/serve.go
@@ -43,6 +43,15 @@ var serveCmd = &cobra.Command{
 				rfc8693RefreshStorePath = "./data/refresh-tokens"
 			}
 		}
+		if serviceIdentityCAPath == "" {
+			serviceIdentityCAPath = os.Getenv("TOKENSMITH_SERVICE_IDENTITY_CA")
+		}
+		if tlsCertFile == "" {
+			tlsCertFile = os.Getenv("TOKENSMITH_TLS_CERT_FILE")
+		}
+		if tlsKeyFile == "" {
+			tlsKeyFile = os.Getenv("TOKENSMITH_TLS_KEY_FILE")
+		}
 
 		// Create token service configuration
 		serviceConfig := tokenservice.Config{
@@ -57,6 +66,9 @@ var serveCmd = &cobra.Command{
 			OIDCClientSecret:          oidcClientSecret,
 			RFC8693BootstrapStorePath: rfc8693BootstrapStorePath,
 			RFC8693RefreshStorePath:   rfc8693RefreshStorePath,
+			ServiceIdentityCAPath:     serviceIdentityCAPath,
+			TLSCertFile:               tlsCertFile,
+			TLSKeyFile:                tlsKeyFile,
 		}
 
 		// Create key manager
@@ -115,10 +127,11 @@ func init() {
 	serveCmd.Flags().StringVar(&keyDir, "key-dir", "", "Directory to save key files")
 	serveCmd.Flags().BoolVar(&nonEnforcing, "non-enforcing", false, "Skip validation checks and only log errors")
 	serveCmd.Flags().BoolVar(&enableLocalUserMint, "enable-local-user-mint", false, "Enable local user-token mint mode (break-glass path)")
+	serveCmd.Flags().StringVar(&serviceIdentityCAPath, "service-identity-ca", "", "Path to PEM CA bundle trusted for inbound service identity client certificates (or set TOKENSMITH_SERVICE_IDENTITY_CA)")
+	serveCmd.Flags().StringVar(&tlsCertFile, "tls-cert-file", "", "Path to TLS server certificate PEM (or set TOKENSMITH_TLS_CERT_FILE)")
+	serveCmd.Flags().StringVar(&tlsKeyFile, "tls-key-file", "", "Path to TLS server private key PEM (or set TOKENSMITH_TLS_KEY_FILE)")
 
 	rootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().StringVar(&rfc8693BootstrapStorePath, "rfc8693-bootstrap-store", "", "Path to RFC 8693 bootstrap token store (or set TOKENSMITH_RFC8693_BOOTSTRAP_STORE; default: ./data/bootstrap-tokens)")
 	serveCmd.Flags().StringVar(&rfc8693RefreshStorePath, "rfc8693-refresh-store", "", "Path to RFC 8693 refresh token family store (or set TOKENSMITH_RFC8693_REFRESH_STORE; default: ./data/refresh-tokens)")
-
-	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/tokenservice/serve_test.go
+++ b/cmd/tokenservice/serve_test.go
@@ -1,0 +1,22 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServeCommandRegisteredOnce(t *testing.T) {
+	count := 0
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == serveCmd.Name() {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count, "serve command should only be registered once")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,6 +72,9 @@ Starts the TokenSmith service.
 | `--enable-local-user-mint` | Enable break-glass local user token creation endpoint | `false` |
 | `--rfc8693-bootstrap-store` | Path to the bootstrap token policy store, or `TOKENSMITH_RFC8693_BOOTSTRAP_STORE` | `./data/bootstrap-tokens` |
 | `--rfc8693-refresh-store` | Path to the refresh token family store, or `TOKENSMITH_RFC8693_REFRESH_STORE` | `./data/refresh-tokens` |
+| `--service-identity-ca` | PEM CA bundle trusted for inbound service-identity mTLS client certificates, or `TOKENSMITH_SERVICE_IDENTITY_CA` | `""` |
+| `--tls-cert-file` | HTTPS server certificate PEM, or `TOKENSMITH_TLS_CERT_FILE` | `""` |
+| `--tls-key-file` | HTTPS server private key PEM, or `TOKENSMITH_TLS_KEY_FILE` | `""` |
 | `--non-enforcing` | Skip strict validation checks and only log errors | `false` |
 | `--config` | Path to JSON config file | `""` |
 
@@ -81,6 +84,7 @@ Starts the TokenSmith service.
 - If `--key-file` is not set, TokenSmith generates an RSA keypair and writes it to `--key-dir` as `private.pem` and `public.pem`.
 - If `--oidc-client-id` or `--oidc-client-secret` are omitted, TokenSmith reads `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET`.
 - If RFC 8693 store flags are omitted, TokenSmith falls back to environment variables and then the defaults shown above.
+- If `--service-identity-ca` is set, TokenSmith requires `--tls-cert-file` and `--tls-key-file` so mTLS service identity exchange can be enforced.
 
 ### Minimal run example
 
@@ -102,6 +106,7 @@ The `serve` command exposes:
 - `GET /.well-known/jwks.json`
 - `POST /oauth/token`
 - `POST /token` (alias for the service-token flow)
+- `POST /service-identity/session` (mTLS service-identity session mint)
 
 See `docs/http-endpoints.md` for request and response formats.
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -16,6 +16,9 @@ This page lists environment variables currently used by TokenSmith code paths.
 | `OIDC_CLIENT_SECRET` | `cmd/tokenservice/serve.go` | Fallback value for `--oidc-client-secret` |
 | `TOKENSMITH_RFC8693_BOOTSTRAP_STORE` | `cmd/tokenservice/serve.go` | Fallback value for `--rfc8693-bootstrap-store`; default `./data/bootstrap-tokens` |
 | `TOKENSMITH_RFC8693_REFRESH_STORE` | `cmd/tokenservice/serve.go` | Fallback value for `--rfc8693-refresh-store`; default `./data/refresh-tokens` |
+| `TOKENSMITH_SERVICE_IDENTITY_CA` | `cmd/tokenservice/serve.go` | Fallback value for `--service-identity-ca` (PEM CA bundle for inbound mTLS client cert trust) |
+| `TOKENSMITH_TLS_CERT_FILE` | `cmd/tokenservice/serve.go` | Fallback value for `--tls-cert-file` (TokenSmith HTTPS server certificate) |
+| `TOKENSMITH_TLS_KEY_FILE` | `cmd/tokenservice/serve.go` | Fallback value for `--tls-key-file` (TokenSmith HTTPS server private key) |
 
 OIDC runtime configuration notes:
 
@@ -54,14 +57,16 @@ Notes:
 | --- | --- | --- |
 | `TOKENSMITH_URL` | Consumer services using `pkg/tokenservice` | Base URL of the TokenSmith service, used to call `POST /oauth/token` |
 | `TOKENSMITH_BOOTSTRAP_TOKEN` | `pkg/tokenservice/client.go` | One-time startup bootstrap token redeemed at `POST /oauth/token` |
+| `TOKENSMITH_SERVICE_IDENTITY_CERT` | `pkg/tokenservice/client.go` | Optional path to service mTLS client certificate used with `POST /service-identity/session` |
+| `TOKENSMITH_SERVICE_IDENTITY_KEY` | `pkg/tokenservice/client.go` | Optional path to service mTLS client private key used with `POST /service-identity/session` |
 | `TOKENSMITH_TARGET_SERVICE` | Consumer service configuration | Common config convention for intended audience service |
 | `TOKENSMITH_SCOPES` | Consumer service configuration | Common config convention for intended scopes |
 | `TOKENSMITH_REFRESH_SKEW_SEC` | Consumer service configuration | Common config convention for refresh lead time |
 
 Notes:
 
-- only `TOKENSMITH_BOOTSTRAP_TOKEN` is read directly by current `pkg/tokenservice/client.go` defaults
-- current `ServiceClient` uses RFC 8693 bootstrap and refresh form fields only
+- `ServiceClient` prefers `TOKENSMITH_SERVICE_IDENTITY_CERT` + `TOKENSMITH_SERVICE_IDENTITY_KEY` when both files are readable, then falls back to `TOKENSMITH_BOOTSTRAP_TOKEN`
+- bootstrap and refresh paths still use RFC 8693 form fields against `POST /oauth/token`
 - target service and scopes are currently authoritative on the server side from bootstrap-token policy and refresh-token family state
 - many consumer services still map `TOKENSMITH_TARGET_SERVICE`, `TOKENSMITH_SCOPES`, and `TOKENSMITH_REFRESH_SKEW_SEC` into explicit client options for local configuration consistency
 

--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -22,6 +22,7 @@ Current response fields include:
 - `cluster_id`
 - `openchami_id`
 - `oidc_issuer`
+- `service_identity_ca_configured`
 
 Example:
 
@@ -113,6 +114,31 @@ Canonical token endpoint for the service-to-service bootstrap and refresh flows.
 Compatibility alias for the same RFC 8693 / RFC 6749 token handling used by the service-token flow.
 
 For new integrations, prefer `POST /oauth/token`.
+
+### `POST /service-identity/session`
+
+Mint an access token + refresh token session using mTLS client identity.
+
+Requirements:
+
+- TokenSmith started with `--service-identity-ca <pem>`
+- TokenSmith started with TLS listener flags (`--tls-cert-file`, `--tls-key-file`)
+- caller presents a client certificate signed by the configured service-identity CA
+
+Behavior:
+
+- service identity subject is extracted from client certificate Common Name (`CN`)
+- TokenSmith looks up policy by subject (same subject/audience/scopes model used by bootstrap policy storage)
+- response shape matches `POST /oauth/token` success payload (`access_token`, `refresh_token`, `expires_in`, etc.)
+
+Example:
+
+```bash
+curl -s https://tokensmith.example/service-identity/session \
+  --cert /etc/openchami/tls/service.crt \
+  --key /etc/openchami/tls/service.key \
+  -X POST | jq
+```
 
 ## Bootstrap token exchange
 

--- a/docs/internal-service-auth.md
+++ b/docs/internal-service-auth.md
@@ -39,7 +39,7 @@ Important:
 - configure verifiers with the JWKS URL directly
 - the `kid` in TokenSmith-issued JWTs is expected to match a key in the published set
 
-## 2) Caller service flow: bootstrap token to service token
+## 2) Caller service flow: mTLS service identity (preferred) or bootstrap token
 
 The service-to-service token flow uses the RFC 8693 token endpoint:
 
@@ -47,6 +47,29 @@ The service-to-service token flow uses the RFC 8693 token endpoint:
 - compatibility alias: `POST /token`
 
 For new integrations, prefer `POST /oauth/token`.
+
+### Service identity mTLS request (preferred)
+
+Caller services can mint startup session credentials by presenting a client certificate:
+
+- endpoint: `POST /service-identity/session`
+- method: `POST`
+- body: empty JSON `{}` (or empty body)
+- TLS: client certificate required; certificate must chain to TokenSmith `--service-identity-ca`
+
+Example:
+
+```bash
+curl -s https://tokensmith.example/service-identity/session \
+  --cert /etc/openchami/tls/service.crt \
+  --key /etc/openchami/tls/service.key \
+  -X POST | jq
+```
+
+`pkg/tokenservice.ServiceClient` behavior:
+
+- if both `TOKENSMITH_SERVICE_IDENTITY_CERT` and `TOKENSMITH_SERVICE_IDENTITY_KEY` are set and readable, it uses `POST /service-identity/session`
+- else, it falls back to bootstrap token exchange via `POST /oauth/token`
 
 ### Bootstrap token request
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,7 @@ exec /usr/local/bin/tokensmith serve \
   --key-dir="$TOKENSMITH_KEY_DIR" \
   --rfc8693-bootstrap-store="$TOKENSMITH_RFC8693_BOOTSTRAP_STORE" \
   --rfc8693-refresh-store="$TOKENSMITH_RFC8693_REFRESH_STORE" \
+  --service-identity-ca="$TOKENSMITH_SERVICE_IDENTITY_CA" \
+  --tls-cert-file="$TOKENSMITH_TLS_CERT_FILE" \
+  --tls-key-file="$TOKENSMITH_TLS_KEY_FILE" \
   "$@"

--- a/pkg/authn/middleware.go
+++ b/pkg/authn/middleware.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/openchami/tokensmith/pkg/authz"
 	"github.com/openchami/tokensmith/pkg/keys"
+	"github.com/openchami/tokensmith/pkg/oidc"
 	tstoken "github.com/openchami/tokensmith/pkg/token"
 	"github.com/rs/zerolog/log"
 )
@@ -328,17 +329,7 @@ func refreshAllJWKS(ctx context.Context, cache *jwksCache, now time.Time, urls [
 }
 
 func bearerToken(authzHeader string) (string, bool) {
-	parts := strings.SplitN(strings.TrimSpace(authzHeader), " ", 2)
-	if len(parts) != 2 {
-		return "", false
-	}
-	if !strings.EqualFold(parts[0], "Bearer") {
-		return "", false
-	}
-	if parts[1] == "" {
-		return "", false
-	}
-	return parts[1], true
+	return oidc.ParseBearerToken(authzHeader)
 }
 
 func stringInSlice(s string, list []string) bool {

--- a/pkg/oidc/middleware.go
+++ b/pkg/oidc/middleware.go
@@ -16,6 +16,23 @@ type TokenCtxKey struct{}
 // IntrospectionCtxKey is the context key for the OIDC introspection result
 type IntrospectionCtxKey struct{}
 
+// ParseBearerToken extracts a bearer token from an Authorization header.
+// It accepts case-insensitive bearer schemes per RFC 6750.
+func ParseBearerToken(authHeader string) (string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(authHeader), " ", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	if !strings.EqualFold(parts[0], "Bearer") {
+		return "", false
+	}
+	token := strings.TrimSpace(parts[1])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
 // RequireToken is middleware that validates the presence and format of an OIDC token
 func RequireToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,15 +43,14 @@ func RequireToken(next http.Handler) http.Handler {
 			return
 		}
 
-		// Check if it's a Bearer token
-		parts := strings.Split(authHeader, " ")
-		if len(parts) != 2 || parts[0] != "Bearer" {
+		token, ok := ParseBearerToken(authHeader)
+		if !ok {
 			http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
 			return
 		}
 
 		// Add token to request context for downstream handlers
-		ctx := context.WithValue(r.Context(), TokenCtxKey{}, parts[1])
+		ctx := context.WithValue(r.Context(), TokenCtxKey{}, token)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/oidc/middleware_test.go
+++ b/pkg/oidc/middleware_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package oidc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBearerToken_CaseInsensitiveScheme(t *testing.T) {
+	token, ok := ParseBearerToken("bearer opaque-token")
+	require.True(t, ok)
+	assert.Equal(t, "opaque-token", token)
+}
+
+func TestRequireToken_AcceptsCaseInsensitiveBearerScheme(t *testing.T) {
+	handler := RequireToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenValue, _ := r.Context().Value(TokenCtxKey{}).(string)
+		_, _ = w.Write([]byte(tokenValue))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oidc/exchange", nil)
+	req.Header.Set("Authorization", "bEaReR opaque-token")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "opaque-token", resp.Body.String())
+}

--- a/pkg/tokenservice/client.go
+++ b/pkg/tokenservice/client.go
@@ -6,6 +6,7 @@ package tokenservice
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 var (
 	ErrMissingBootstrapToken = errors.New("missing bootstrap token")
 	ErrMissingRefreshToken   = errors.New("missing refresh token")
+	ErrTLSClientMaterial     = errors.New("invalid service identity client certificate configuration")
 	ErrEmptyTokenSmithURL    = errors.New("tokensmith URL is required")
 	ErrEmptyTargetService    = errors.New("target service is required")
 	ErrRefreshTokenExpired   = errors.New("refresh token expired")
@@ -41,6 +43,8 @@ type ServiceClient struct {
 	serviceID               string
 	targetService           string
 	bootstrapToken          string
+	serviceIdentityCertPath string
+	serviceIdentityKeyPath  string
 	refreshBefore           time.Duration
 	autoInterval            time.Duration
 	bootstrapMaxAttempts    int
@@ -89,6 +93,15 @@ func WithHTTPClient(httpClient *http.Client) ServiceClientOption {
 func WithBootstrapToken(token string) ServiceClientOption {
 	return func(c *ServiceClient) {
 		c.bootstrapToken = strings.TrimSpace(token)
+	}
+}
+
+// WithServiceIdentityCertKey configures client-certificate material used to obtain
+// a service session from /service-identity/session.
+func WithServiceIdentityCertKey(certPath, keyPath string) ServiceClientOption {
+	return func(c *ServiceClient) {
+		c.serviceIdentityCertPath = strings.TrimSpace(certPath)
+		c.serviceIdentityKeyPath = strings.TrimSpace(keyPath)
 	}
 }
 
@@ -311,6 +324,10 @@ func (c *ServiceClient) GetToken(ctx context.Context) error {
 		return c.requestServiceToken(ctx, "refresh")
 	}
 
+	if certPath, keyPath, ok := c.readableServiceIdentityPaths(); ok {
+		return c.requestServiceIdentitySession(ctx, certPath, keyPath)
+	}
+
 	return c.requestServiceToken(ctx, "bootstrap")
 }
 
@@ -345,11 +362,33 @@ func (c *ServiceClient) requestServiceToken(ctx context.Context, grantType strin
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return c.doTokenRequest(req)
+}
 
+func (c *ServiceClient) requestServiceIdentitySession(ctx context.Context, certPath, keyPath string) error {
+	mtlsClient, err := c.clientWithMutualTLS(certPath, keyPath)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/service-identity/session", c.tokensmithURL), strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return c.doTokenRequestWithClient(mtlsClient, req)
+}
+
+func (c *ServiceClient) doTokenRequest(req *http.Request) error {
+	return c.doTokenRequestWithClient(c.client, req)
+}
+
+func (c *ServiceClient) doTokenRequestWithClient(httpClient *http.Client, req *http.Request) error {
 	now := time.Now().UTC()
 	atomic.StoreInt64(&c.lastRefreshUnix, now.Unix())
 
-	resp, err := c.client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		atomic.AddUint64(&c.refreshFailures, 1)
 		wrapped := fmt.Errorf("failed to get token: %w", err)
@@ -479,12 +518,86 @@ func (c *ServiceClient) currentBootstrapToken() string {
 	return strings.TrimSpace(os.Getenv(BootstrapTokenEnvVar))
 }
 
+func (c *ServiceClient) currentServiceIdentityCertPath() string {
+	if c.serviceIdentityCertPath != "" {
+		return c.serviceIdentityCertPath
+	}
+	return strings.TrimSpace(os.Getenv(ServiceIdentityCertEnvVar))
+}
+
+func (c *ServiceClient) currentServiceIdentityKeyPath() string {
+	if c.serviceIdentityKeyPath != "" {
+		return c.serviceIdentityKeyPath
+	}
+	return strings.TrimSpace(os.Getenv(ServiceIdentityKeyEnvVar))
+}
+
+func (c *ServiceClient) readableServiceIdentityPaths() (certPath, keyPath string, ok bool) {
+	certPath = c.currentServiceIdentityCertPath()
+	keyPath = c.currentServiceIdentityKeyPath()
+	if certPath == "" || keyPath == "" {
+		return "", "", false
+	}
+
+	if certInfo, err := os.Stat(certPath); err != nil || certInfo.IsDir() {
+		return "", "", false
+	}
+	if keyInfo, err := os.Stat(keyPath); err != nil || keyInfo.IsDir() {
+		return "", "", false
+	}
+
+	return certPath, keyPath, true
+}
+
+func (c *ServiceClient) clientWithMutualTLS(certPath, keyPath string) (*http.Client, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to load cert/key pair: %v", ErrTLSClientMaterial, err)
+	}
+
+	baseTransport, err := cloneTransport(c.client.Transport)
+	if err != nil {
+		return nil, err
+	}
+	if baseTransport.TLSClientConfig == nil {
+		baseTransport.TLSClientConfig = &tls.Config{}
+	} else {
+		baseTransport.TLSClientConfig = baseTransport.TLSClientConfig.Clone()
+	}
+	baseTransport.TLSClientConfig.Certificates = append([]tls.Certificate(nil), cert)
+
+	out := *c.client
+	out.Transport = baseTransport
+	return &out, nil
+}
+
+func cloneTransport(rt http.RoundTripper) (*http.Transport, error) {
+	if rt == nil {
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, fmt.Errorf("%w: default transport type is unsupported", ErrTLSClientMaterial)
+		}
+		return defaultTransport.Clone(), nil
+	}
+
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("%w: custom transport must be *http.Transport", ErrTLSClientMaterial)
+	}
+	return transport.Clone(), nil
+}
+
 func (c *ServiceClient) validateConfig() error {
 	if strings.TrimSpace(c.tokensmithURL) == "" {
 		return ErrEmptyTokenSmithURL
 	}
 	if strings.TrimSpace(c.targetService) == "" {
 		return ErrEmptyTargetService
+	}
+	certPath := c.currentServiceIdentityCertPath()
+	keyPath := c.currentServiceIdentityKeyPath()
+	if (certPath == "") != (keyPath == "") {
+		return fmt.Errorf("%w: both %s and %s must be set together", ErrTLSClientMaterial, ServiceIdentityCertEnvVar, ServiceIdentityKeyEnvVar)
 	}
 	return nil
 }

--- a/pkg/tokenservice/client_test.go
+++ b/pkg/tokenservice/client_test.go
@@ -6,10 +6,19 @@ package tokenservice
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -369,4 +378,152 @@ func TestServiceClientStartAutoRefreshStopsOnRefreshTokenExpired(t *testing.T) {
 	case <-time.After(2500 * time.Millisecond):
 		t.Fatal("StartAutoRefresh did not exit after refresh token expiry")
 	}
+}
+
+func TestServiceClientInitialize_UsesServiceIdentitySessionWhenCertConfigured(t *testing.T) {
+	caPEM, certPath, keyPath := writeServiceIdentityCertFiles(t, "metadata-service")
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(caPEM))
+
+	var serviceIdentityCalls atomic.Int32
+	var bootstrapCalls atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/service-identity/session":
+			serviceIdentityCalls.Add(1)
+			require.NotNil(t, r.TLS)
+			require.NotEmpty(t, r.TLS.PeerCertificates)
+			_ = json.NewEncoder(w).Encode(OAuthTokenResponse{
+				AccessToken:      "mtls-access-token",
+				TokenType:        "Bearer",
+				ExpiresIn:        1800,
+				RefreshToken:     "mtls-refresh-token",
+				RefreshExpiresIn: 86400,
+				IssuedTokenType:  AccessTokenTypeRFC8693,
+			})
+		case "/oauth/token":
+			bootstrapCalls.Add(1)
+			http.Error(w, "bootstrap flow should not be used when mTLS identity is configured", http.StatusBadRequest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  caPool,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	client := NewServiceClientWithOptions(
+		server.URL,
+		"metadata-service",
+		"metadata-service-id",
+		"instance-1",
+		"cluster-1",
+		WithHTTPClient(server.Client()),
+		WithServiceIdentityCertKey(certPath, keyPath),
+		WithTargetService("smd"),
+	)
+
+	require.NoError(t, client.Initialize(context.Background()))
+	assert.Equal(t, int32(1), serviceIdentityCalls.Load())
+	assert.Equal(t, int32(0), bootstrapCalls.Load())
+}
+
+func TestServiceClientInitialize_FallsBackToBootstrapWhenServiceIdentityFilesUnreadable(t *testing.T) {
+	var bootstrapCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/oauth/token", r.URL.Path)
+		bootstrapCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(OAuthTokenResponse{
+			AccessToken:      "bootstrap-access-token",
+			TokenType:        "Bearer",
+			ExpiresIn:        1800,
+			RefreshToken:     "bootstrap-refresh-token",
+			RefreshExpiresIn: 86400,
+			IssuedTokenType:  AccessTokenTypeRFC8693,
+		})
+	}))
+	defer server.Close()
+
+	client := NewServiceClientWithOptions(
+		server.URL,
+		"metadata-service",
+		"metadata-service-id",
+		"instance-2",
+		"cluster-1",
+		WithBootstrapToken("bootstrap-token"),
+		WithServiceIdentityCertKey("/does/not/exist.crt", "/does/not/exist.key"),
+		WithTargetService("smd"),
+	)
+
+	require.NoError(t, client.Initialize(context.Background()))
+	assert.Equal(t, int32(1), bootstrapCalls.Load())
+}
+
+func TestServiceClientInitialize_FailsWhenOnlyOneServiceIdentityPathProvided(t *testing.T) {
+	client := NewServiceClientWithOptions(
+		"http://tokensmith.local",
+		"metadata-service",
+		"metadata-service-id",
+		"instance-3",
+		"cluster-1",
+		WithServiceIdentityCertKey("/tmp/service.crt", ""),
+		WithTargetService("smd"),
+	)
+
+	err := client.Initialize(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTLSClientMaterial)
+}
+
+func writeServiceIdentityCertFiles(t *testing.T, subjectCN string) ([]byte, string, string) {
+	t.Helper()
+
+	now := time.Now()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(100),
+		Subject:               pkix.Name{CommonName: "tokensmith-test-ca"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(101),
+		Subject: pkix.Name{
+			CommonName:   subjectCN,
+			Organization: []string{"openchami"},
+		},
+		NotBefore:   now.Add(-time.Hour),
+		NotAfter:    now.Add(24 * time.Hour),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "service.crt")
+	keyPath := filepath.Join(tempDir, "service.key")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	return caPEM, certPath, keyPath
 }

--- a/pkg/tokenservice/handlers.go
+++ b/pkg/tokenservice/handlers.go
@@ -6,9 +6,12 @@ package tokenservice
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -171,14 +174,19 @@ func (s *TokenService) OIDCConfigHandler(w http.ResponseWriter, r *http.Request)
 
 // TokenExchangeHandler handles token exchange requests.
 func (s *TokenService) TokenExchangeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
 		http.Error(w, "Missing authorization header", http.StatusUnauthorized)
 		return
 	}
 
-	parts := strings.Split(authHeader, " ")
-	if len(parts) != 2 || parts[0] != "Bearer" {
+	token, ok := oidc.ParseBearerToken(authHeader)
+	if !ok {
 		http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
 		return
 	}
@@ -187,15 +195,15 @@ func (s *TokenService) TokenExchangeHandler(w http.ResponseWriter, r *http.Reque
 		Scope         []string `json:"scope"`
 		TargetService string   `json:"target_service"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
 	ctx := context.WithValue(r.Context(), ScopeContextKey, payload.Scope)
 	ctx = context.WithValue(ctx, TargetServiceContextKey, payload.TargetService)
 
-	tokenValue, err := s.ExchangeToken(ctx, parts[1])
+	tokenValue, err := s.ExchangeToken(ctx, token)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -213,20 +221,17 @@ func (s *TokenService) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"status":       "healthy",
-		"service":      "tokensmith",
-		"issuer":       s.Issuer,
-		"cluster_id":   s.ClusterID,
-		"openchami_id": s.OpenCHAMIID,
-		"oidc_issuer":  s.Config.OIDCIssuerURL,
+		"status":                         "healthy",
+		"service":                        "tokensmith",
+		"issuer":                         s.Issuer,
+		"cluster_id":                     s.ClusterID,
+		"openchami_id":                   s.OpenCHAMIID,
+		"oidc_issuer":                    s.Config.OIDCIssuerURL,
+		"service_identity_ca_configured": s.serviceIdentityCAPool != nil,
 	})
 }
 
-// Start starts the HTTP server.
-func (s *TokenService) Start(port int) error {
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	logger := log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-
+func (s *TokenService) newRouter(logger zerolog.Logger) http.Handler {
 	r := chi.NewRouter()
 	r.Use(openchami_logger.OpenCHAMILogger(logger))
 	r.Use(middleware.RequestID)
@@ -243,8 +248,7 @@ func (s *TokenService) Start(port int) error {
 		r.Group(func(r chi.Router) {
 			r.Use(oidc.RequireToken)
 			r.Use(s.withCurrentOIDCProvider)
-			r.Post("/token", s.TokenExchangeHandler)
-			r.Get("/token", s.TokenExchangeHandler)
+			r.Post("/exchange", s.TokenExchangeHandler)
 		})
 	})
 	r.Route("/admin/oidc", func(r chi.Router) {
@@ -255,8 +259,44 @@ func (s *TokenService) Start(port int) error {
 	// See: https://datatracker.ietf.org/doc/html/rfc8693
 	r.Post("/oauth/token", s.OAuthTokenHandler)
 	r.Post("/token", s.OAuthTokenHandler) // Alias for compatibility
+	r.Post("/service-identity/session", s.ServiceIdentitySessionHandler)
+
+	return r
+}
+
+// Start starts the HTTP server.
+func (s *TokenService) Start(port int) error {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	logger := log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	addr := fmt.Sprintf(":%d", port)
-	fmt.Printf("Starting server on %s\n", addr)
-	return http.ListenAndServe(addr, r)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: s.newRouter(logger),
+	}
+
+	tlsCert := strings.TrimSpace(s.Config.TLSCertFile)
+	tlsKey := strings.TrimSpace(s.Config.TLSKeyFile)
+
+	switch {
+	case (tlsCert == "") != (tlsKey == ""):
+		return fmt.Errorf("both TLS server cert and key must be provided together")
+	case tlsCert != "" && tlsKey != "":
+		server.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+		if s.serviceIdentityCAPool != nil {
+			server.TLSConfig.ClientAuth = tls.VerifyClientCertIfGiven
+			server.TLSConfig.ClientCAs = s.serviceIdentityCAPool
+		}
+
+		fmt.Printf("Starting TLS server on %s\n", addr)
+		return server.ListenAndServeTLS(tlsCert, tlsKey)
+	default:
+		if s.serviceIdentityCAPool != nil {
+			return fmt.Errorf("service identity CA is configured but TLS server cert/key are not; mTLS requires --tls-cert-file and --tls-key-file")
+		}
+		fmt.Printf("Starting server on %s\n", addr)
+		return server.ListenAndServe()
+	}
 }

--- a/pkg/tokenservice/handlers_test.go
+++ b/pkg/tokenservice/handlers_test.go
@@ -1,0 +1,123 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package tokenservice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openchami/tokensmith/pkg/oidc"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoutes_OAuthTokenUsesRFC8693Handler(t *testing.T) {
+	svc := newTestTokenService(t, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-test",
+		OpenCHAMIID: "openchami-test",
+	})
+
+	router := svc.newRouter(zerolog.New(io.Discard))
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+
+	var oauthErr OAuthErrorResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&oauthErr))
+	assert.Equal(t, "invalid_request", oauthErr.Error)
+	assert.Contains(t, oauthErr.ErrorDescription, "grant_type")
+}
+
+func TestTokenExchangeHandler_MethodNotAllowed(t *testing.T) {
+	svc := newTestTokenService(t, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-test",
+		OpenCHAMIID: "openchami-test",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/exchange", nil)
+	resp := httptest.NewRecorder()
+
+	svc.TokenExchangeHandler(resp, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, resp.Code)
+}
+
+func TestTokenExchangeHandler_InvalidJSONReturnsBadRequest(t *testing.T) {
+	svc := newTestTokenService(t, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-test",
+		OpenCHAMIID: "openchami-test",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/exchange", strings.NewReader("{invalid"))
+	req.Header.Set("Authorization", "Bearer opaque-id-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	svc.TokenExchangeHandler(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, resp.Body.String(), "invalid request body")
+}
+
+func TestTokenExchangeHandler_AcceptsCaseInsensitiveBearer(t *testing.T) {
+	svc := newTestTokenService(t, Config{
+		Issuer:      "http://tokensmith.test",
+		ClusterID:   "cluster-test",
+		OpenCHAMIID: "openchami-test",
+		GroupScopes: map[string][]string{
+			"viewer": {"read"},
+		},
+	})
+
+	mockProvider := oidc.NewMockProvider()
+	mockProvider.IntrospectTokenFunc = func(ctx context.Context, token string) (*oidc.IntrospectionResponse, error) {
+		now := time.Now()
+		return &oidc.IntrospectionResponse{
+			Active:    true,
+			Username:  "case-user",
+			ExpiresAt: now.Add(time.Hour).Unix(),
+			IssuedAt:  now.Unix(),
+			Claims: map[string]interface{}{
+				"aud":          []interface{}{"svc-target"},
+				"groups":       []interface{}{"viewer"},
+				"auth_level":   "IAL2",
+				"auth_factors": float64(2),
+				"auth_methods": []interface{}{"password", "mfa"},
+				"session_id":   "sid-case-user",
+				"session_exp":  float64(now.Add(time.Hour).Unix()),
+				"auth_events":  []interface{}{"login"},
+			},
+			TokenType: "Bearer",
+		}, nil
+	}
+	svc.OIDCProvider = mockProvider
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/exchange", strings.NewReader(`{"scope":["read"],"target_service":"svc-target"}`))
+	req.Header.Set("Authorization", "bearer opaque-id-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	svc.TokenExchangeHandler(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var tokenResp map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+	assert.NotEmpty(t, tokenResp["access_token"])
+	assert.Equal(t, "Bearer", tokenResp["token_type"])
+}

--- a/pkg/tokenservice/mint.go
+++ b/pkg/tokenservice/mint.go
@@ -113,6 +113,15 @@ func (s *TokenService) UpdateGroupScopes(groupScopes map[string][]string) {
 // bootstrap token's server-side policy.
 // See: RFC 8693 Section 2.2.1 (Access Token Response)
 func (s *TokenService) GenerateServiceToken(subject, audience string, scopes []string, ttl time.Duration) (string, error) {
+	return s.generateServiceTokenWithContext(subject, audience, scopes, ttl, "bootstrap_exchange", "bootstrap_token_exchange", "bootstrap-exchange")
+}
+
+// GenerateServiceIdentityToken issues an access token from mTLS service identity proof.
+func (s *TokenService) GenerateServiceIdentityToken(subject, audience string, scopes []string, ttl time.Duration) (string, error) {
+	return s.generateServiceTokenWithContext(subject, audience, scopes, ttl, "service_identity_mtls", "service_identity_session", "service-identity")
+}
+
+func (s *TokenService) generateServiceTokenWithContext(subject, audience string, scopes []string, ttl time.Duration, authMethod, authEvent, sessionPrefix string) (string, error) {
 	if subject == "" {
 		return "", errors.New("subject cannot be empty")
 	}
@@ -139,10 +148,10 @@ func (s *TokenService) GenerateServiceToken(subject, audience string, scopes []s
 		Scope:       append([]string(nil), scopes...), // Immutable server-determined scopes
 		AuthLevel:   "IAL2",
 		AuthFactors: 2,
-		AuthMethods: []string{"bootstrap_exchange"},
-		SessionID:   fmt.Sprintf("bootstrap-exchange-%s-%d", subject, now.UnixNano()),
+		AuthMethods: []string{authMethod},
+		SessionID:   fmt.Sprintf("%s-%s-%d", sessionPrefix, subject, now.UnixNano()),
 		SessionExp:  now.Add(ttl).Unix(),
-		AuthEvents:  []string{"bootstrap_token_exchange"},
+		AuthEvents:  []string{authEvent},
 	}
 
 	return s.TokenManager.GenerateToken(claims)

--- a/pkg/tokenservice/rfc8693_storage.go
+++ b/pkg/tokenservice/rfc8693_storage.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -133,6 +134,53 @@ func (s *BootstrapTokenStore) GetPolicy(tokenHash string) (*BootstrapTokenPolicy
 	return policy, nil
 }
 
+// GetLatestPolicyBySubject finds the most recently-created bootstrap policy for a subject.
+// This supports service-identity minting where subject -> policy mapping is required.
+func (s *BootstrapTokenStore) GetLatestPolicyBySubject(subject string) (*BootstrapTokenPolicy, error) {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return nil, fmt.Errorf("subject is required")
+	}
+
+	var best *BootstrapTokenPolicy
+
+	s.mu.RLock()
+	for _, policy := range s.policies {
+		if policy == nil || policy.Subject != subject {
+			continue
+		}
+		if best == nil || policy.CreatedAt.After(best.CreatedAt) {
+			best = policy
+		}
+	}
+	s.mu.RUnlock()
+
+	// Fast path: prefer in-memory cache when available to avoid repeated full disk scans.
+	if best != nil {
+		return best, nil
+	}
+
+	diskBest, err := s.loadLatestPolicyBySubjectFromDisk(subject)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("bootstrap token policy not found for subject %q", subject)
+		}
+		return nil, err
+	}
+
+	// Promote to memory cache for subsequent O(1) retrieval by hash.
+	s.mu.Lock()
+	if existing, exists := s.policies[diskBest.TokenHash]; exists {
+		best = existing
+	} else {
+		s.policies[diskBest.TokenHash] = diskBest
+		best = diskBest
+	}
+	s.mu.Unlock()
+
+	return best, nil
+}
+
 // loadPolicyFromDisk reads and validates a single bootstrap policy file by token hash.
 func (s *BootstrapTokenStore) loadPolicyFromDisk(tokenHash string) (*BootstrapTokenPolicy, error) {
 	filePath := filepath.Join(s.storePath, tokenHash+".json")
@@ -155,6 +203,46 @@ func (s *BootstrapTokenStore) loadPolicyFromDisk(tokenHash string) (*BootstrapTo
 	}
 
 	return &policy, nil
+}
+
+func (s *BootstrapTokenStore) loadLatestPolicyBySubjectFromDisk(subject string) (*BootstrapTokenPolicy, error) {
+	entries, err := os.ReadDir(s.storePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, os.ErrNotExist
+		}
+		return nil, fmt.Errorf("failed to read bootstrap token store directory: %w", err)
+	}
+
+	var best *BootstrapTokenPolicy
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		filePath := filepath.Join(s.storePath, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		var policy BootstrapTokenPolicy
+		if err := json.Unmarshal(data, &policy); err != nil {
+			continue
+		}
+		if policy.Subject != subject || strings.TrimSpace(policy.TokenHash) == "" {
+			continue
+		}
+		if best == nil || policy.CreatedAt.After(best.CreatedAt) {
+			policyCopy := policy
+			best = &policyCopy
+		}
+	}
+
+	if best == nil {
+		return nil, os.ErrNotExist
+	}
+	return best, nil
 }
 
 // UpdatePolicy updates a bootstrap token policy (e.g., mark as consumed).

--- a/pkg/tokenservice/rfc8693_storage_test.go
+++ b/pkg/tokenservice/rfc8693_storage_test.go
@@ -157,3 +157,89 @@ func TestBootstrapTokenStore_GetPolicy_ConcurrentFallback(t *testing.T) {
 		require.NoError(t, callErr)
 	}
 }
+
+func TestBootstrapTokenStore_GetLatestPolicyBySubject_PrefersNewest(t *testing.T) {
+	storePath := t.TempDir()
+	store, err := NewBootstrapTokenStore(storePath)
+	require.NoError(t, err)
+
+	now := time.Now().Add(-time.Minute)
+	old := &BootstrapTokenPolicy{
+		ID:         "bt-old",
+		Subject:    "boot-service",
+		Audience:   "smd-old",
+		TokenHash:  HashBootstrapToken("old"),
+		TTL:        10 * time.Minute,
+		RefreshTTL: 24 * time.Hour,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}
+	newer := &BootstrapTokenPolicy{
+		ID:         "bt-new",
+		Subject:    "boot-service",
+		Audience:   "smd-new",
+		TokenHash:  HashBootstrapToken("new"),
+		TTL:        10 * time.Minute,
+		RefreshTTL: 24 * time.Hour,
+		CreatedAt:  now.Add(30 * time.Second),
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}
+
+	require.NoError(t, store.SavePolicy(old))
+	require.NoError(t, store.SavePolicy(newer))
+
+	policy, err := store.GetLatestPolicyBySubject("boot-service")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.Equal(t, "smd-new", policy.Audience)
+}
+
+func TestBootstrapTokenStore_GetLatestPolicyBySubject_InMemoryFastPathSkipsDiskScan(t *testing.T) {
+	storePath := t.TempDir()
+	store, err := NewBootstrapTokenStore(storePath)
+	require.NoError(t, err)
+
+	now := time.Now()
+	policy := &BootstrapTokenPolicy{
+		ID:         "bt-fastpath",
+		Subject:    "boot-service",
+		Audience:   "smd",
+		TokenHash:  HashBootstrapToken("fastpath"),
+		TTL:        10 * time.Minute,
+		RefreshTTL: 24 * time.Hour,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}
+	require.NoError(t, store.SavePolicy(policy))
+
+	// If disk scanning is attempted, this path causes os.ReadDir to fail with ENOTDIR.
+	store.storePath = filepath.Join(storePath, policy.TokenHash+".json")
+
+	found, err := store.GetLatestPolicyBySubject("boot-service")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, policy.TokenHash, found.TokenHash)
+}
+
+func TestBootstrapTokenStore_GetLatestPolicyBySubject_FallbackToDisk(t *testing.T) {
+	storePath := t.TempDir()
+	store, err := NewBootstrapTokenStore(storePath)
+	require.NoError(t, err)
+
+	policy := &BootstrapTokenPolicy{
+		ID:         "bt-disk",
+		Subject:    "metadata-service",
+		Audience:   "smd",
+		TokenHash:  HashBootstrapToken("disk"),
+		TTL:        10 * time.Minute,
+		RefreshTTL: 24 * time.Hour,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+	}
+	writePolicyFileForTest(t, storePath, policy)
+
+	found, err := store.GetLatestPolicyBySubject("metadata-service")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, policy.TokenHash, found.TokenHash)
+}

--- a/pkg/tokenservice/service.go
+++ b/pkg/tokenservice/service.go
@@ -6,6 +6,7 @@ package tokenservice
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -35,6 +36,11 @@ type Config struct {
 	// RFC 8693 stores (opaque token and family management)
 	RFC8693BootstrapStorePath string
 	RFC8693RefreshStorePath   string
+
+	// Service-identity mTLS trust anchor and TLS listener settings.
+	ServiceIdentityCAPath string
+	TLSCertFile           string
+	TLSKeyFile            string
 
 	// OIDC provider configuration
 	OIDCIssuerURL    string
@@ -90,6 +96,9 @@ type TokenService struct {
 	// Phase 3: per-IP rate limiting for failed bootstrap exchanges
 	// (NIST SP 800-63-4 Section 5.2.2)
 	replayLimiter *replayLimiter
+
+	// Trust roots for inbound mTLS service identity certificates.
+	serviceIdentityCAPool *x509.CertPool
 }
 
 // NewTokenService creates a new TokenService instance
@@ -119,6 +128,14 @@ func NewTokenService(keyManager *keys.KeyManager, config Config) (*TokenService,
 		OpenCHAMIID:   config.OpenCHAMIID,
 		OIDCProvider:  oidcProvider,
 		replayLimiter: newReplayLimiter(),
+	}
+
+	if strings.TrimSpace(config.ServiceIdentityCAPath) != "" {
+		caPool, err := loadCertPoolFromPEMFile(config.ServiceIdentityCAPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load service identity CA bundle: %w", err)
+		}
+		svc.serviceIdentityCAPool = caPool
 	}
 
 	// Initialize RFC 8693 stores for opaque bootstrap and refresh tokens
@@ -155,6 +172,20 @@ func NewTokenService(keyManager *keys.KeyManager, config Config) (*TokenService,
 	svc.refreshTokenStore = refreshStore
 
 	return svc, nil
+}
+
+func loadCertPoolFromPEMFile(path string) (*x509.CertPool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PEM file %q: %w", path, err)
+	}
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(data); !ok {
+		return nil, fmt.Errorf("PEM file %q did not contain any valid certificates", path)
+	}
+
+	return pool, nil
 }
 
 func (s *TokenService) currentOIDCProvider() oidc.Provider {

--- a/pkg/tokenservice/service_identity.go
+++ b/pkg/tokenservice/service_identity.go
@@ -1,0 +1,151 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package tokenservice
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	serviceIdentityAccessTTL = 3600 * time.Second
+)
+
+// ServiceIdentitySessionHandler exchanges a validated mTLS client certificate
+// for an access+refresh token session using preconfigured subject policy.
+func (s *TokenService) ServiceIdentitySessionHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.writeOAuthError(w, http.StatusMethodNotAllowed, "invalid_request", "Method not allowed")
+		return
+	}
+
+	if s.serviceIdentityCAPool == nil {
+		s.writeOAuthError(w, http.StatusServiceUnavailable, "server_error", "Service identity CA is not configured")
+		return
+	}
+
+	peerCerts, err := peerCertificatesFromRequest(r)
+	if err != nil {
+		s.writeOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+
+	if err := verifyClientCertificateChain(peerCerts, s.serviceIdentityCAPool); err != nil {
+		s.writeOAuthError(w, http.StatusUnauthorized, "invalid_client", "Client certificate verification failed")
+		return
+	}
+
+	subject, err := serviceIdentitySubjectFromCertificate(peerCerts[0])
+	if err != nil {
+		s.writeOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+
+	policy, err := s.bootstrapTokenStore.GetLatestPolicyBySubject(subject)
+	if err != nil {
+		s.writeOAuthError(w, http.StatusForbidden, "invalid_client", "No policy configured for service identity subject")
+		return
+	}
+
+	accessToken, err := s.GenerateServiceIdentityToken(policy.Subject, policy.Audience, policy.Scopes, serviceIdentityAccessTTL)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("component", "tokenservice").
+			Str("handler", "service_identity_session").
+			Str("subject", policy.Subject).
+			Msg("Failed to generate service identity access token")
+		s.writeOAuthError(w, http.StatusInternalServerError, "server_error", "An internal server error occurred")
+		return
+	}
+
+	refreshToken, familyID, err := s.GenerateRefreshToken(policy.Subject, policy.Audience, policy.Scopes, policy.RefreshTTL)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("component", "tokenservice").
+			Str("handler", "service_identity_session").
+			Str("subject", policy.Subject).
+			Msg("Failed to generate service identity refresh token")
+		s.writeOAuthError(w, http.StatusInternalServerError, "server_error", "An internal server error occurred")
+		return
+	}
+
+	log.Info().
+		Str("component", "tokenservice").
+		Str("handler", "service_identity_session").
+		Str("subject", policy.Subject).
+		Str("audience", policy.Audience).
+		Strs("scopes", policy.Scopes).
+		Str("refresh_family_id", familyID).
+		Msg("Service identity mTLS certificate exchanged for service session")
+
+	s.writeOAuthTokenResponse(w, http.StatusOK, OAuthTokenResponse{
+		AccessToken:      accessToken,
+		TokenType:        "Bearer",
+		ExpiresIn:        int(serviceIdentityAccessTTL.Seconds()),
+		RefreshToken:     refreshToken,
+		RefreshExpiresIn: int(policy.RefreshTTL.Seconds()),
+		Scope:            strings.Join(policy.Scopes, " "),
+		IssuedTokenType:  AccessTokenTypeRFC8693,
+	})
+}
+
+func peerCertificatesFromRequest(r *http.Request) ([]*x509.Certificate, error) {
+	if r.TLS == nil {
+		return nil, fmt.Errorf("TLS client certificate is required")
+	}
+	if len(r.TLS.PeerCertificates) == 0 {
+		return nil, fmt.Errorf("TLS client certificate is required")
+	}
+	return r.TLS.PeerCertificates, nil
+}
+
+func verifyClientCertificateChain(chain []*x509.Certificate, roots *x509.CertPool) error {
+	if len(chain) == 0 {
+		return fmt.Errorf("certificate chain is empty")
+	}
+	if roots == nil {
+		return fmt.Errorf("service identity CA trust roots are not configured")
+	}
+
+	leaf := chain[0]
+	opts := x509.VerifyOptions{
+		Roots:       roots,
+		CurrentTime: time.Now(),
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if len(chain) > 1 {
+		opts.Intermediates = x509.NewCertPool()
+		for _, cert := range chain[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+	}
+
+	if _, err := leaf.Verify(opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// serviceIdentitySubjectFromCertificate maps a client cert to service identity.
+// Rule: use Subject.CommonName as the service subject (e.g. CN=boot-service).
+func serviceIdentitySubjectFromCertificate(cert *x509.Certificate) (string, error) {
+	if cert == nil {
+		return "", fmt.Errorf("client certificate is required")
+	}
+
+	subject := strings.TrimSpace(cert.Subject.CommonName)
+	if subject == "" {
+		return "", fmt.Errorf("client certificate subject CN is required")
+	}
+	return subject, nil
+}

--- a/pkg/tokenservice/service_test.go
+++ b/pkg/tokenservice/service_test.go
@@ -8,8 +8,13 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -751,4 +756,131 @@ func TestOAuthTokenHandler_BootstrapExchangeThenRefresh(t *testing.T) {
 	replayRefreshW := httptest.NewRecorder()
 	service.OAuthTokenHandler(replayRefreshW, replayRefreshReq)
 	assert.Equal(t, http.StatusBadRequest, replayRefreshW.Result().StatusCode)
+}
+
+func TestServiceIdentitySessionHandler_Success(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyManager := keys.NewKeyManager()
+	require.NoError(t, keyManager.SetKeyPair(privateKey, &privateKey.PublicKey))
+
+	caPEM, serviceCert := generateClientIdentityCertificate(t, "boot-service")
+	caPath := filepath.Join(t.TempDir(), "service-identity-ca.pem")
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0600))
+
+	service, err := NewTokenService(keyManager, Config{
+		Issuer:                    "http://tokensmith.test",
+		ClusterID:                 "cluster-a",
+		OpenCHAMIID:               "openchami-a",
+		RFC8693BootstrapStorePath: filepath.Join(t.TempDir(), "bootstrap-tokens"),
+		RFC8693RefreshStorePath:   filepath.Join(t.TempDir(), "refresh-tokens"),
+		ServiceIdentityCAPath:     caPath,
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	require.NoError(t, service.bootstrapTokenStore.SavePolicy(&BootstrapTokenPolicy{
+		ID:         "policy-1",
+		Subject:    "boot-service",
+		Audience:   "metadata-service",
+		Scopes:     []string{"read"},
+		TokenHash:  HashBootstrapToken("placeholder"),
+		TTL:        10 * time.Minute,
+		RefreshTTL: 24 * time.Hour,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(10 * time.Minute),
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/service-identity/session", strings.NewReader("{}"))
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{serviceCert},
+	}
+	w := httptest.NewRecorder()
+
+	service.ServiceIdentitySessionHandler(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var oauthResp OAuthTokenResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&oauthResp))
+	require.NotEmpty(t, oauthResp.AccessToken)
+	require.NotEmpty(t, oauthResp.RefreshToken)
+	assert.Equal(t, "Bearer", oauthResp.TokenType)
+
+	claims, _, err := service.TokenManager.ParseToken(oauthResp.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "boot-service", claims.Subject)
+	assert.Equal(t, []string{"metadata-service"}, []string(claims.Audience))
+	assert.Equal(t, []string{"service_identity_mtls"}, claims.AuthMethods)
+}
+
+func TestServiceIdentitySessionHandler_RequiresClientCertificate(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyManager := keys.NewKeyManager()
+	require.NoError(t, keyManager.SetKeyPair(privateKey, &privateKey.PublicKey))
+
+	caPEM, _ := generateClientIdentityCertificate(t, "boot-service")
+	caPath := filepath.Join(t.TempDir(), "service-identity-ca.pem")
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0600))
+
+	service, err := NewTokenService(keyManager, Config{
+		Issuer:                "http://tokensmith.test",
+		ClusterID:             "cluster-a",
+		OpenCHAMIID:           "openchami-a",
+		ServiceIdentityCAPath: caPath,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/service-identity/session", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	service.ServiceIdentitySessionHandler(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+}
+
+func generateClientIdentityCertificate(t *testing.T, subjectCN string) ([]byte, *x509.Certificate) {
+	t.Helper()
+
+	now := time.Now()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tokensmith-service-identity-ca"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(48 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	serviceKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	serviceTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName:   subjectCN,
+			Organization: []string{"openchami"},
+		},
+		NotBefore:   now.Add(-time.Hour),
+		NotAfter:    now.Add(24 * time.Hour),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	serviceDER, err := x509.CreateCertificate(rand.Reader, serviceTemplate, caCert, &serviceKey.PublicKey, caKey)
+	require.NoError(t, err)
+	serviceCert, err := x509.ParseCertificate(serviceDER)
+	require.NoError(t, err)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caDER,
+	})
+	return caPEM, serviceCert
 }

--- a/pkg/tokenservice/service_token_contract.go
+++ b/pkg/tokenservice/service_token_contract.go
@@ -5,7 +5,9 @@
 package tokenservice
 
 const (
-	BootstrapTokenEnvVar = "TOKENSMITH_BOOTSTRAP_TOKEN"
+	BootstrapTokenEnvVar      = "TOKENSMITH_BOOTSTRAP_TOKEN"
+	ServiceIdentityCertEnvVar = "TOKENSMITH_SERVICE_IDENTITY_CERT"
+	ServiceIdentityKeyEnvVar  = "TOKENSMITH_SERVICE_IDENTITY_KEY"
 
 	RefreshTokenUseClaim = "refresh_token"
 	RefreshTokenUseField = "token_use"


### PR DESCRIPTION
- Added support for mutual TLS (mTLS) in the token service to authenticate service identities using client certificates.
- Introduced `ServiceIdentitySessionHandler` to handle token requests from mTLS clients.
- Updated `TokenExchangeHandler` to enforce HTTP POST method and improved error handling for invalid requests.
- Enhanced token generation methods to support service identity tokens.
- Implemented tests for service identity session handling, including successful exchanges and error scenarios.
- Updated configuration to include service identity CA paths and TLS settings.
- Added new methods for managing service identity policies and retrieving the latest policies by subject.

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [X] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
